### PR TITLE
NOT DONE: Fullscreen graph

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,8 @@ Changelog of lizard-nxt client
 
 Unreleased (1.2.dev) (XXXX-XX-XX)
 ---------------------
--
+
+- Added full screen graph.
 
 
 Release 1.1.3 (2014-12-30)


### PR DESCRIPTION
## Problem
Graphs are small.

## Solution
Add 'fullscreen' functionality. 

## Todo
- [ ] Merge dashboard stuff @arjenvrielink and @ernstkui have been working on
- [ ] Opening fullscreen mode graph happens in dashboard mode
- [ ] Closing dashboard returns to 'previous state'

