### PR TITLE
Fix time zoom button behaviour for min and max time extent

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog of lizard-nxt client
 Unreleased (1.1.4) (XXXX-XX-XX)
 -------------------------------
 
+- Limit timeline min and max zoom.
+
 - Baselayergroups now share a single button in datamenu.
 
 - Dashboard button moved to omnibox.

--- a/app/components/timeline/time-controller.js
+++ b/app/components/timeline/time-controller.js
@@ -278,8 +278,10 @@ angular.module('lizard-nxt')
 
       var milliseconds = UtilService.getCurrentWidth() * newResolution;
 
-      State.temporal.start = State.temporal.at - milliseconds;
-      State.temporal.end = State.temporal.at + milliseconds;
+      State.temporal.start = Math.max(State.temporal.at - milliseconds,
+                                      UtilService.MIN_TIME);
+      State.temporal.end = Math.min(State.temporal.at + milliseconds,
+                                    UtilService.MAX_TIME);
       State.temporal.resolution = newResolution;
 
       // Without this $broadcast, timeline will not sync to State.temporal:


### PR DESCRIPTION
### Issue
Zoom buttons for time didn't respect min and max time extent.

### Fix
Limit min and max time extent for zoom buttons.