### PR TITLE
Fix the buggaloo using D3's tickFormat function

### DIFF
--- a/app/lib/nxt-d3-service.js
+++ b/app/lib/nxt-d3-service.js
@@ -12,7 +12,7 @@
  * directly by calling NxtD3Service.<method>(<args>).
  */
 angular.module('lizard-nxt')
-  .factory("NxtD3", [ function () {
+  .factory("NxtD3", [function () {
 
   var createCanvas, createElementForAxis, resizeCanvas;
 
@@ -254,9 +254,10 @@ angular.module('lizard-nxt')
      */
     _makeAxis: function (scale, options) {
       // Make an axis for d3 based on a scale
-      var axis = d3.svg.axis()
-        .scale(scale)
-        .orient(options.orientation);
+      var DECIMAL_COUNT = 2,
+          axis = d3.svg.axis()
+            .scale(scale)
+            .orient(options.orientation);
       if (options.ticks) {
         axis.ticks(options.ticks);
       } else {
@@ -276,7 +277,9 @@ angular.module('lizard-nxt')
         if (options.tickFormat) {
           axis.tickFormat(options.tickFormat);
         } else {
-          axis.tickFormat(this._localeFormatter.nl_NL.numberFormat());
+          axis.tickFormat(function (d) {
+            return d3.format("." + DECIMAL_COUNT + "f")(d);
+          });
         }
       }
       return axis;

--- a/app/lib/util-service.js
+++ b/app/lib/util-service.js
@@ -713,6 +713,5 @@ angular.module('lizard-nxt')
     } else {
       throw new Error("This aint a valid triple to convert into rgbString: " + rgbTriple);
     }
-
   };
 }]);


### PR DESCRIPTION
This PR fixes the y-axis (tick-) labeling in the omnibox. Because of floating-point errors, a computed value for a tick in the D3 scale's domain could e.g. become 23.05000000000001 (a.o.t. 23.05). This would result in the visual part of the tick label becoming a non-informative "000001" (a.o.t. "23.05") since numbers by convention get aligned to the right, and we have only limited space for the tick-label.