### PR TITLE
Fix rain slug confusions, store is now

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,8 @@ Changelog of lizard-nxt client
 
 Unreleased (1.2.7) (XXXX-XX-XX)
 -------------------------------
--
+
+- Fix radar/basic slug confusion, store slug is now `rain`.
 
 
 Release 1.2.10 (2015-1-22)

--- a/app/components/omnibox/controllers/area-controller.js
+++ b/app/components/omnibox/controllers/area-controller.js
@@ -60,8 +60,8 @@ angular.module('omnibox')
             $scope.box.content.elevation.layers["dem/nl"].data
               = RasterService.handleElevationCurve(response.data);
             break;
-          case "radar/basic":
-            $scope.box.content.rain.layers["radar/basic"].data
+          case "rain":
+            $scope.box.content.rain.layers["rain"].data
               = response.data;
             $scope.filteredRainDataPerKilometer
               = UtilService.getFilteredRainDataPerKM(

--- a/app/components/omnibox/controllers/line-controller.js
+++ b/app/components/omnibox/controllers/line-controller.js
@@ -40,9 +40,9 @@ angular.module('omnibox')
           $scope.box.content[response.layerGroupSlug]
             .layers[response.layerSlug]
             .data = response.data;
-        } else if (response.layerSlug === 'radar/basic') {
+        } else if (response.layerSlug === 'rain') {
           // We dont wanna show intersect for rain (d.d. 20-01-2015)
-          delete $scope.box.content[response.layerGroupSlug].layers['radar/basic'];
+          delete $scope.box.content[response.layerGroupSlug].layers['rain'];
         } else if (response.data && response.data !== 'null'
           && response.format === 'Store'
           && (response.scale === 'ratio' || response.scale === 'interval')

--- a/app/components/omnibox/controllers/point-controller.js
+++ b/app/components/omnibox/controllers/point-controller.js
@@ -51,7 +51,7 @@ angular.module('omnibox')
             response.data.entity_name + '$' + response.data.id
           );
         }
-        if (response.layerSlug === 'radar/basic' && response.data !== null) {
+        if (response.layerSlug === 'rain' && response.data !== null) {
           // this logs incessant errors.
           if ($scope.box.content[response.layerGroupSlug] === undefined) { return; }
           if (!$scope.box.content[response.layerGroupSlug].layers.hasOwnProperty(response.layerSlug)) { return; }

--- a/app/components/omnibox/controllers/rain-controller.js
+++ b/app/components/omnibox/controllers/rain-controller.js
@@ -22,16 +22,16 @@ angular.module('omnibox')
     if (!$scope.$$phase) {
       $scope.$apply(function () {
         $scope.rrc.active = !$scope.rrc.active;
-        $scope.lg.layers['radar/basic'].changed = !$scope.lg.layers['radar/basic'].changed;
+        $scope.lg.layers['rain'].changed = !$scope.lg.layers['rain'].changed;
       });
     } else {
       $scope.rrc.active = !$scope.rrc.active;
-      $scope.lg.layers['radar/basic'].changed = !$scope.lg.layers['radar/basic'].changed;
+      $scope.lg.layers['rain'].changed = !$scope.lg.layers['rain'].changed;
     }
   };
 
 
-  $scope.$watch("lg.layers['radar/basic'].changed", function (n, o) {
+  $scope.$watch("lg.layers['rain'].changed", function (n, o) {
     if (n === o || !$scope.rrc.active) { return; }
     getRecurrenceTime();
   });
@@ -41,7 +41,7 @@ angular.module('omnibox')
 
     // TODO: refactor this shit
     RasterService.getData(
-     {slug: 'radar/basic'}, {
+     {slug: 'rain'}, {
       agg: 'rrc',
       geom: State.spatial.here,
       start: State.temporal.start,

--- a/app/components/omnibox/templates/rain.html
+++ b/app/components/omnibox/templates/rain.html
@@ -10,8 +10,8 @@
        <graph
          bar-chart
          class="xyGraph"
-         data="lg.layers['radar/basic'].data"
-         ylabel="lg.layers['radar/basic'].aggWindow"
+         data="lg.layers['rain'].data"
+         ylabel="lg.layers['rain'].aggWindow"
          yfilter="aggWinToYLabel"
          keys="{x: 0, y: 1}"
          temporal="omnibox.state.temporal">
@@ -25,7 +25,7 @@
          <a
            class="btn btn-default btn-xs"
            title="Data van deze infocard exporteren"
-           ng-csv="formatCSVColumns(lg.layers['radar/basic'].data)"
+           ng-csv="formatCSVColumns(lg.layers['rain'].data)"
            filename="neerslag.csv"
            csv-header="['Datestamp', 'Timestamp', 'Rain (mm)', 'Latitude', 'Longitude']" >
            <i class="fa fa-share-square-o"></i>

--- a/app/components/timeline/timeline-directives.js
+++ b/app/components/timeline/timeline-directives.js
@@ -190,7 +190,7 @@ angular.module('lizard-nxt')
               timelineLayers.events.layers.push(layer);
               timelineLayers.events.slugs.push(layer.slug);
             } else if (layer.format === "Store" &&
-                       layer.slug === "radar/basic") {
+                       layer.slug === "rain") {
               timelineLayers.rain = layer;
             }
           });


### PR DESCRIPTION
### Issue
Database gets confused when two layers have the same slug

### Fix
Update rain store slug in database to `rain`. Then also update check in timeline directive to proper slug.