### PR TITLE
Arjen rain style wms animate

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,8 @@ Changelog of lizard-nxt client
 
 Unreleased (1.2.7) (XXXX-XX-XX)
 -------------------------------
--
+
+- Get colormap per aggWindow for rain.
 
 
 Release 1.2.10 (2015-1-22)

--- a/app/components/map/services/non-tiled-wms-layer-service.js
+++ b/app/components/map/services/non-tiled-wms-layer-service.js
@@ -216,9 +216,14 @@ angular.module('map')
               // for now this is only for the radar stores
               if (this.slug.split('/')[0] === 'radar') {
                 // change image url based on timestate.
+                // TODO: check scope
+                var storeName = this._determineStore(timeState).name;
+                this.options.styles = this.options.styles.split('-')[0] +
+                                      '-' +
+                                      storeName.split('/')[1];
                 this._imageUrlBase = RasterService.buildURLforWMS(
                     this,
-                    this._determineStore(timeState).name
+                    storeName
                     );
                 this._temporalResolution = this._determineStore(timeState).resolution;
               }


### PR DESCRIPTION
### Issue
When switching aggWindow for rain animation 5min, hour and day aggregates are shown accordingly but not yet the corresponding colormap.

### Fix
Assign colormap dynamically. Update fixture.

related to https://github.com/nens/lizard-nxt/pull/635