### PR TITLE
Renamed weir attribute

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Unreleased (1.2.7) (XXXX-XX-XX)
 
 - Fix radar/basic slug confusion, store slug is now `rain`.
 
+- Rename weir attribute.
+
 
 Release 1.2.10 (2015-1-22)
 ---------------------

--- a/app/components/omnibox/wanted-attrs-constant.js
+++ b/app/components/omnibox/wanted-attrs-constant.js
@@ -660,7 +660,7 @@ angular.module('omnibox')
         defaultValue: "-0.3"
       },
       {
-        keyName: "Controle",
+        keyName: "Bediening",
         attrName: "controlled",
         ngBindValue:
           "waterchain.layers.waterchain_grid.data.controlled",


### PR DESCRIPTION
### Issue
Attribute `controlled` of weir was translated wrong.

### Fix
Use proper translation.

related to: https://github.com/nens/hydra-core/pull/130