### PR TITLE
DONE: Ernst tiled non tiled

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@ Unreleased (1.2.7) (XXXX-XX-XX)
 
 - Use current spatial bounds for animation.
 
-- Make wms request with EPSG3857 for image overlays.
+- Make wms request with EPSG3857 for image overlays and tiled wms.
 
 
 Release 1.2.19 (2015-1-27)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,9 @@ Changelog of lizard-nxt client
 
 Unreleased (1.2.7) (XXXX-XX-XX)
 -------------------------------
--
+- Use current spatial bounds for animation.
+
+- Make wms request with EPSG3857 for image overlays.
 
 
 Release 1.2.19 (2015-1-27)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ Changelog of lizard-nxt client
 
 Unreleased (1.2.7) (XXXX-XX-XX)
 -------------------------------
+- No redraw of temporal raster when nothing relevant changed.
+
 - Use current spatial bounds for animation.
 
 - Make wms request with EPSG3857 for image overlays.

--- a/app/components/map/services/map-service.js
+++ b/app/components/map/services/map-service.js
@@ -56,7 +56,7 @@ angular.module('map')
             });
           } else {
             angular.forEach(layerGroup.mapLayers, function (layer) {
-              layer.timeState = timeState;
+              layer.timeState = angular.copy(timeState);
             });
           }
         });

--- a/app/components/map/services/map-service.js
+++ b/app/components/map/services/map-service.js
@@ -445,6 +445,7 @@ angular.module('map')
           version: '1.1.1',
           minZoom: nonLeafLayer.min_zoom || 0,
           maxZoom: 19,
+          crs: LeafletService.CRS.EPSG3857,
           opacity: nonLeafLayer.opacity,
           zIndex: nonLeafLayer.zIndex
         };

--- a/app/components/map/services/non-tiled-wms-layer-service.js
+++ b/app/components/map/services/non-tiled-wms-layer-service.js
@@ -209,12 +209,6 @@ angular.module('map')
             syncTime: function (timeState, map) {
               var defer = $q.defer();
 
-              if (this.timeState.at === timeState.at
-                && this.timeState.aggWindow === timeState.aggWindow) {
-                defer.resolve();
-                return defer.promise;
-              }
-
               this.timeState = timeState;
 
               // this only works for stores with different aggregation levels

--- a/app/components/map/services/non-tiled-wms-layer-service.js
+++ b/app/components/map/services/non-tiled-wms-layer-service.js
@@ -122,6 +122,7 @@ angular.module('map')
                 maxZoom: 19,
                 opacity: layer.opacity,
                 zindex: layer.zIndex,
+                crs: LeafletService.CRS.EPSG3857,
                 time: this._formatter(date)
               };
 

--- a/app/components/map/services/non-tiled-wms-layer-service.js
+++ b/app/components/map/services/non-tiled-wms-layer-service.js
@@ -201,7 +201,8 @@ angular.module('map')
               this._imageUrlBase = RasterService.buildURLforWMS(
                 this,
                 map,
-                store.name
+                store.name,
+                timeState.playing
               );
               this.options.styles = this.options.styles.split('-')[0]
                 + '-'

--- a/app/components/map/services/non-tiled-wms-layer-service.js
+++ b/app/components/map/services/non-tiled-wms-layer-service.js
@@ -195,7 +195,16 @@ angular.module('map')
             syncTime: function (timeState, map) {
               var defer = $q.defer();
 
-              this.timeState = timeState;
+              // Resolve and return when nothing changed.
+              if (timeState.at === this.timeState.at
+                && timeState.aggWindow === this.timeState.aggWindow
+                && timeState.playing === this.timeState.playing) {
+                defer.resolve();
+                return defer.promise;
+              }
+
+              // Store copy no reference.
+              this.timeState = angular.copy(timeState);
 
               // this only works for stores with different aggregation levels
               // for now this is only for the radar stores

--- a/app/components/map/services/non-tiled-wms-layer-service.js
+++ b/app/components/map/services/non-tiled-wms-layer-service.js
@@ -91,7 +91,7 @@ angular.module('map')
           // resolution, animation will also move slowly, so there is no need
           // for a big buffer.
           Object.defineProperty(layer, '_bufferLength', {
-            value: layer._temporalResolution >= 3600000 ? 2 : 10,
+            value: layer._temporalResolution >= 3600000 ? 2 : 6,
             writable: true,
           });
           // Number of rasters currently underway.
@@ -114,7 +114,6 @@ angular.module('map')
                   date = new Date(this._mkTimeStamp(this.timeState.at)),
                   store = this._determineStore(this.timeState);
 
-
               var options = {
                 layers: store.name,
                 format: 'image/png',
@@ -136,6 +135,7 @@ angular.module('map')
                 LeafletService.tileLayer.wms(layer.url, options)
               ];
 
+              // defer is passed to loadlistener to be resolved when done.
               this._addLoadListener(
                 this._imageOverlays[0].addTo(map),
                 this.timeState.at,
@@ -209,6 +209,8 @@ angular.module('map')
                 + store.name.split('/')[1];
 
               this._syncToNewTime(timeState, map, defer);
+
+              return defer.promise;
             },
 
             /**
@@ -256,8 +258,6 @@ angular.module('map')
               else {
                 this._tiledSyncTime(map, currentDate, defer);
               }
-
-              return defer.promise;
             },
 
             _tiledSyncTime: function (map, currentDate, defer) {
@@ -406,7 +406,6 @@ angular.module('map')
              */
             _replaceUrlFromFrame: function (frameIndex, defer) {
               var url = this._imageUrlBase + this._formatter(new Date(this._nxtDate));
-              console.log(url);
               var frame = this._imageOverlays[frameIndex];
               frame.off('load');
               frame.setOpacity(0);

--- a/app/components/map/services/non-tiled-wms-layer-service.js
+++ b/app/components/map/services/non-tiled-wms-layer-service.js
@@ -121,7 +121,7 @@ angular.module('map')
                 minZoom: layer.min_zoom || 0,
                 maxZoom: 19,
                 opacity: layer.opacity,
-                zindex: layer.zIndex,
+                zIndex: layer.zIndex,
                 crs: LeafletService.CRS.EPSG3857,
                 time: this._formatter(date)
               };
@@ -153,37 +153,6 @@ angular.module('map')
             /**
              * @summary    Sets the new timeState on the layer. And updates the layer
              *             to the new time.
-             *
-             * @decription When there are not enough imageOverlays, more overlays
-             *             are added to the map. The curent timeState.at is rounded
-             *             to the nearest date value present on the wms server. The
-             *             currentDate value is used to lookup the index of the
-             *             frame in the _frameLookup. The _frameLookup contains all
-             *             the dates that are present in the buffer and the index
-             *             of the imageoverlay it is stored on:
-             *
-             *               { <date in ms from epoch> : <index on _imageOverlays> }
-             *
-             *               length is 0, 1 or _bufferLength.
-             *
-             *             The date is either: 1. present in the lookup in case the
-             *             index is defined or 2. not present in case this frame is
-             *             not loaded yet.
-             *
-             *             When 1. The imageOverlay with index <currentOverlayIndex>
-             *             is set to _opacity and the defer is resolved. The image
-             *             sources of the _imageOverlays with opacity !== 0 are set
-             *             to the next date not in the _frameLookup, the opacity is
-             *             set to 0 and the reference is removed from the
-             *             _frameLookup. A loadListener adds a new reference to the
-             *             _frameLookup when the layer finishes loading a new frame.
-             *
-             *             When 2. All references are removed and all layers get a
-             *             new source. When the new source is different than the one
-             *             it currently has, the loadListener is removed and a new
-             *             one source and loadlistener are added. When all layers
-             *             have loaded, the first layer's opacity is set to _opacity
-             *             and the defer is resolved.
              *
              * @parameter timeState nxt object containing current time on at.
              * @parameter map leaflet map to add layers to.
@@ -281,11 +250,58 @@ angular.module('map')
               }
             },
 
+            /**
+             * synToTime with a tiled layer. Simpy removes everything and uses
+             * add method to create a new tiled layer
+             * @param  {object} map         leaflet map
+             * @param  {int}    currentDate ms from epoch
+             * @param  {object} defer       defer to resolve when done
+             */
             _tiledSyncTime: function (map, currentDate, defer) {
               this.remove(map);
               this.add(map, defer);
             },
 
+            /**
+             * synToTime with imageOverlays for animation. See syncTime docstr
+             * for more info.
+             *
+             * @decription When there are not enough or the imageOverlays have
+             *             an outdated bounds, more overlays are added to the
+             *             map. The curent timeState.at is rounded
+             *             to the nearest date value present on the wms server. The
+             *             currentDate value is used to lookup the index of the
+             *             frame in the _frameLookup. The _frameLookup contains all
+             *             the dates that are present in the buffer and the index
+             *             of the imageoverlay it is stored on:
+             *
+             *               { <date in ms from epoch> : <index on _imageOverlays> }
+             *
+             *               length is 0, 1 or _bufferLength.
+             *
+             *             The date is either: 1. present in the lookup in case the
+             *             index is defined or 2. not present in case this frame is
+             *             not loaded yet.
+             *
+             *             When 1. The imageOverlay with index <currentOverlayIndex>
+             *             is set to _opacity and the defer is resolved. The image
+             *             sources of the _imageOverlays with opacity !== 0 are set
+             *             to the next date not in the _frameLookup, the opacity is
+             *             set to 0 and the reference is removed from the
+             *             _frameLookup. A loadListener adds a new reference to the
+             *             _frameLookup when the layer finishes loading a new frame.
+             *
+             *             When 2. All references are removed and all layers get a
+             *             new source. When the new source is different than the one
+             *             it currently has, the loadListener is removed and a new
+             *             one source and loadlistener are added. When all layers
+             *             have loaded, the first layer's opacity is set to _opacity
+             *             and the defer is resolved.
+             *
+             * @param  {object} map         leaflet map
+             * @param  {int}    currentDate ms from epoch
+             * @param  {object} defer       defer to resolve when done
+             */
             _animateSyncTime: function (map, currentDate, defer) {
               var newBounds = map.getBounds();
 

--- a/app/components/map/services/non-tiled-wms-layer-service.js
+++ b/app/components/map/services/non-tiled-wms-layer-service.js
@@ -239,19 +239,25 @@ angular.module('map')
               return;
             },
 
+            /**
+             * Takes a new timeState and delegates to sync functions for
+             * animation or non-animation.
+             * @param  {object} map         leaflet map
+             * @param  {int}    currentDate ms from epoch
+             * @param  {object} defer       defer to resolve when done
+             */
             _syncToNewTime: function (timeState, map, defer) {
               var currentDate = this._mkTimeStamp(timeState.at);
               if (timeState.playing) {
                 this._animateSyncTime(map, currentDate, defer);
               }
-
               else {
                 this._tiledSyncTime(map, currentDate, defer);
               }
             },
 
             /**
-             * synToTime with a tiled layer. Simpy removes everything and uses
+             * syncToTime with a tiled layer. Simpy removes everything and uses
              * add method to create a new tiled layer
              * @param  {object} map         leaflet map
              * @param  {int}    currentDate ms from epoch
@@ -263,7 +269,7 @@ angular.module('map')
             },
 
             /**
-             * synToTime with imageOverlays for animation. See syncTime docstr
+             * syncToTime with imageOverlays for animation. See syncTime docstr
              * for more info.
              *
              * @decription When there are not enough or the imageOverlays have

--- a/app/lib/raster-service.js
+++ b/app/lib/raster-service.js
@@ -71,12 +71,13 @@ angular.module('lizard-nxt')
       ',' + [imgBounds[1][1], imgBounds[0][0]].toString();
   };
 
-  var buildURLforWMS = function (wmsLayer, store) {
+  var buildURLforWMS = function (wmsLayer, map, store) {
     var layerName = store || wmsLayer.slug;
+    var bounds = map.getBounds();
 
     var imgBounds = [
-      [wmsLayer.bounds.north, wmsLayer.bounds.west],
-      [wmsLayer.bounds.south, wmsLayer.bounds.east]
+      [bounds.getNorth(), bounds.getWest()],
+      [bounds.getSouth(), bounds.getEast()]
     ],
     opts = wmsLayer.options,
     result = wmsLayer.url

--- a/app/lib/raster-service.js
+++ b/app/lib/raster-service.js
@@ -71,7 +71,7 @@ angular.module('lizard-nxt')
       ',' + [imgBounds[1][1], imgBounds[0][0]].toString();
   };
 
-  var buildURLforWMS = function (wmsLayer, map, store) {
+  var buildURLforWMS = function (wmsLayer, map, store, singleTile) {
     var layerName = store || wmsLayer.slug;
     var bounds = map.getBounds();
 
@@ -85,6 +85,14 @@ angular.module('lizard-nxt')
       + '&SRS=EPSG%3A4326&LAYERS=' + layerName
       + '&BBOX=' + _buildBbox(imgBounds);
 
+    if (singleTile) {
+      var size = map.getPixelBounds().getSize();
+      opts.height = Math.round(size.y / size.x * 512);
+      opts.width = Math.round(size.x / size.y  * 512);
+    } else {
+      opts.height = 256;
+      opts.width = 256;
+    }
 
     angular.forEach(opts, function (v, k) {
       result += UtilService.buildString('&', k.toUpperCase(), "=", v);

--- a/app/lib/raster-service.js
+++ b/app/lib/raster-service.js
@@ -83,8 +83,9 @@ angular.module('lizard-nxt')
    * @return {string}            url
    */
   var buildURLforWMS = function (wmsLayer, map, store, singleTile) {
-    var layerName = store || wmsLayer.slug;
-    var bounds = map.getBounds();
+    var layerName = store || wmsLayer.slug,
+        bounds = map.getBounds(),
+        DEFAULT_TILE_SIZE = 256; // in px
 
     var imgBounds = [
       LeafletService.CRS.EPSG3857.project(bounds.getSouthWest()),
@@ -98,12 +99,12 @@ angular.module('lizard-nxt')
 
     if (singleTile) {
       var size = map.getPixelBounds().getSize();
-      opts.height = Math.round(size.y / size.x * 256);
-      opts.width = Math.round(size.x / size.y  * 256);
+      opts.height = Math.round(size.y / size.x * DEFAULT_TILE_SIZE);
+      opts.width = Math.round(size.x / size.y  * DEFAULT_TILE_SIZE);
     } else {
       // Serve square tiles
-      opts.height = 256;
-      opts.width = 256;
+      opts.height = DEFAULT_TILE_SIZE;
+      opts.width = DEFAULT_TILE_SIZE;
     }
 
     angular.forEach(opts, function (v, k) {

--- a/app/lib/raster-service.js
+++ b/app/lib/raster-service.js
@@ -72,6 +72,16 @@ angular.module('lizard-nxt')
       ',' + [imgBounds[1].x, imgBounds[1].y].toString();
   };
 
+  /**
+   * Returns wms url as used by the non-tiled layer for animation.
+   *
+   * @param  {object} wmsLayer   nxt map layer instance with options and slug.
+   * @param  {object} map        current leaflet map
+   * @param  {string} store         name of store rain-5min|rain-hour etc.
+   * @param  {boolean} singleTile when single it returns a proper tilesize
+   *                              otherwise just 256x256px.
+   * @return {string}            url
+   */
   var buildURLforWMS = function (wmsLayer, map, store, singleTile) {
     var layerName = store || wmsLayer.slug;
     var bounds = map.getBounds();

--- a/app/styles/_leaflet-overrides.scss
+++ b/app/styles/_leaflet-overrides.scss
@@ -22,6 +22,10 @@
     position: relative;
 }
 
+.leaflet-container img.leaflet-image-layer {
+    max-width: none !important;
+}
+
 .leaflet-bar {
     a {
         &:last-child {
@@ -72,12 +76,6 @@
             color: $white;
         }
 
-    }
-
-    img.leaflet-image-layer {
-        -webkit-filter: contrast(200%);
-        filter: contrast(200%);
-        max-width: none !important;
     }
 
 }

--- a/test/karma.conf.dev.js
+++ b/test/karma.conf.dev.js
@@ -72,7 +72,7 @@ module.exports = function(config) {
     // - PhantomJS
     // - IE (only Windows)
     browsers: [
-      'Chrome'
+      'phantomjs'
     ],
 
     // Which plugins to enable

--- a/test/karma.conf.dev.js
+++ b/test/karma.conf.dev.js
@@ -72,7 +72,7 @@ module.exports = function(config) {
     // - PhantomJS
     // - IE (only Windows)
     browsers: [
-      'PhantomJS'
+      'Chrome'
     ],
 
     // Which plugins to enable

--- a/test/karma.conf.dev.js
+++ b/test/karma.conf.dev.js
@@ -72,7 +72,7 @@ module.exports = function(config) {
     // - PhantomJS
     // - IE (only Windows)
     browsers: [
-      'phantomjs'
+      'PhantomJS'
     ],
 
     // Which plugins to enable

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -73,19 +73,20 @@ module.exports = function(config) {
     // - PhantomJS
     // - IE (only Windows)
     browsers: [
-      'PhantomJS'
+      'Chrome'
     ],
 
     // Which plugins to enable
     plugins: [
       'karma-phantomjs-launcher',
+      'karma-chrome-launcher',
       'karma-jasmine',
       'karma-coverage',
       'karma-junit-reporter'
     ],
 
     preprocessors: {
-      'app/**/*.js': ['coverage']  
+      'app/**/*.js': ['coverage']
     },
 
     reporters: ['progress', 'coverage'],
@@ -105,7 +106,7 @@ module.exports = function(config) {
 
     // Continuous Integration mode
     // if true, it capture browsers, run tests and exit
-    singleRun: true,
+    singleRun: false,
 
     colors: true,
 

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -73,7 +73,7 @@ module.exports = function(config) {
     // - PhantomJS
     // - IE (only Windows)
     browsers: [
-      'phantomjs'
+      'PhantomJS'
     ],
 
     // Which plugins to enable

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -73,7 +73,7 @@ module.exports = function(config) {
     // - PhantomJS
     // - IE (only Windows)
     browsers: [
-      'Chrome'
+      'phantomjs'
     ],
 
     // Which plugins to enable
@@ -106,7 +106,7 @@ module.exports = function(config) {
 
     // Continuous Integration mode
     // if true, it capture browsers, run tests and exit
-    singleRun: false,
+    singleRun: true,
 
     colors: true,
 

--- a/test/spec/raster-service-tests.js
+++ b/test/spec/raster-service-tests.js
@@ -23,4 +23,32 @@ describe('Testing raster service', function () {
     expect(result.hasOwnProperty('then')).toBe(true);
   });
 
+  it('should create an image url with height and witdh of 256 when tiled', function () {
+    var layer = {options: {}, url: ''}, // mock wmslayer
+        store = 'test',
+        el = angular.element('<div style="height: 200px; width: 300px; position: absolute;"></div>')
+        map = window.L.map(angular.element('<div></div>')[0], {
+          center: [1, 1],
+          zoom: 13
+        });
+    var url = RasterService.buildURLforWMS(layer, map, store, false);
+    expect(url.split('HEIGHT=')[1].split('&')[0]).toEqual(url.split('WIDTH=')[1].split('&')[0]);
+    expect(Number(url.split('HEIGHT=')[1].split('&')[0])).toBe(256);
+  });
+
+  it('should create an image url with epsg 3857 and converted BBOX', function () {
+    var layer = {options: {}, url: ''}, // mock wmslayer
+        store = 'test',
+        el = angular.element('<div></div>')
+        map = window.L.map(angular.element('<div></div>')[0], {
+          center: [52, 6],
+          zoom: 13
+        });
+    var url = RasterService.buildURLforWMS(layer, map, store, true);
+    expect(url.split('SRS=')[1].split('&')[0]).toBe('EPSG%3A3857');
+    expect(url.split('BBOX=')[1].split('&')[0]).toBe(
+      '667925.8624129414,6800124.675105345,667925.8624129414,6800124.675105345');
+  });
+
+
 });


### PR DESCRIPTION
Dynamic bounds for more pixels and less data :trophy: 

Makes requests in 3857 which also fixes small gaps between radar images :trophy: .

Animated images are now tiled when not animating and shows tiles the size of the map when animating. 

Because imags are smaller, the buffer can also be smaller which makes the animation start up faster :trophy: . 

Removed contrast css filter to make tiled and non-tiled appear the same again
