### PR TITLE
Add CNAME for custom subdomain gh-pages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,24 +3,30 @@ Changelog of lizard-nxt client
 
 Unreleased (1.2.7) (XXXX-XX-XX)
 -------------------------------
+
+- Add CNAME file for gh-pages subdomain.
+
 - No redraw of temporal raster when nothing relevant changed.
 
 - Use current spatial bounds for animation.
 
-- Make wms request with EPSG3857 for image overlays and tiled wms.
+- Make wms request with EPSG:3857 for image overlays and tiled wms.
 
 
 Release 1.2.19 (2015-1-27)
 ---------------------
+
 - Fix syncTime.
 
 Release 1.2.18 (2015-1-27)
 ---------------------
+
 - Fix bug for rain layer.
 
 
 Release 1.2.17 (2015-1-27)
 ---------------------
+
 - Fix bug for non-tiled-wms layer. ZVP broken styles.
 
 

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+development.lizard.net


### PR DESCRIPTION
### Issue
we have a github pages site that is now only reachable at http://nens.github.io/lizard-client/. We want it to be available under development.lizard.net as well.

### Fix
Add CNAME file to repository as per https://help.github.com/articles/adding-a-cname-file-to-your-repository/