### PR TITLE
Always pass integers as start and end to timeseries endpoint

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog of lizard-nxt client
 Unreleased (1.2.7) (XXXX-XX-XX)
 -------------------------------
 
+- Always pass integer timestamp to timeseries endpoint.
+
 - Update release documentation.
 
 - Fix bug with bar size when event.

--- a/app/lib/timeseries-service.js
+++ b/app/lib/timeseries-service.js
@@ -7,8 +7,8 @@ angular.module('lizard-nxt')
     var getTimeseries = function (id, timeState) {
       return CabinetService.timeseries.get({
         object: id,
-        start: timeState.start,
-        end: timeState.end
+        start: parseInt(timeState.start, 10),
+        end: parseInt(timeState.end, 10)
       });
     };
 


### PR DESCRIPTION
### Issue
https://github.com/nens/lizard-nxt/issues/665

### Fix
parseInt() when requesting timeseries.