### PR TITLE
Replace hard coded aggregation type for rain in timeline directive with ...

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog of lizard-nxt client
 Unreleased (1.2.7) (XXXX-XX-XX)
 -------------------------------
 
+- Dynamic aggregation type for rain timeline data.
+
 - Update release documentation.
 
 - Fix bug with bar size when event.

--- a/app/components/timeline/timeline-directives.js
+++ b/app/components/timeline/timeline-directives.js
@@ -297,13 +297,14 @@ angular.module('lizard-nxt')
 
       // Has it's own deferrer to not conflict with
       // other deferrers with the same layerSlug
+      console.log(rasterLayer);
       RasterService.getData(
         rasterLayer,
         {
           geom: bounds,
           start: start,
           end: stop,
-          agg: 'none',
+          agg: rasterLayer.aggregationType,
           aggWindow: State.temporal.aggWindow,
           deferrer: {
             origin: 'timeline_' + rasterLayer,

--- a/app/components/timeline/timeline-directives.js
+++ b/app/components/timeline/timeline-directives.js
@@ -297,7 +297,6 @@ angular.module('lizard-nxt')
 
       // Has it's own deferrer to not conflict with
       // other deferrers with the same layerSlug
-      console.log(rasterLayer);
       RasterService.getData(
         rasterLayer,
         {


### PR DESCRIPTION
...layer aggregation type

### Issue
Aggregation type for rain layer in timeline directive was hard coded.

### Fix
Use aggregation type of layer.

related to https://github.com/nens/lizard-nxt/pull/704