### PR TITLE
Add lookup filters for weir and culvert attributes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Unreleased (1.2.7) (XXXX-XX-XX)
 
 - Scenario table without table header and scrollable.
 
+- Add lookup filter for culvert and weir attributes.
+
 
 Release 1.2.25 (2015-2-19)
 ---------------------

--- a/app/components/omnibox/wanted-attrs-constant.js
+++ b/app/components/omnibox/wanted-attrs-constant.js
@@ -96,7 +96,7 @@ angular.module('omnibox')
         keyName: "Materiaal",
         attrName: "material",
         ngBindValue:
-          "waterchain.layers.waterchain_grid.data.material | truncate: 20",
+          "waterchain.layers.waterchain_grid.data.material | lookupCulvertMaterial",
         valueSuffix: "",
         defaultValue: "beton"
       },
@@ -104,7 +104,7 @@ angular.module('omnibox')
         keyName: "Vorm",
         attrName: "shape",
         ngBindValue:
-          "waterchain.layers.waterchain_grid.data.shape | truncate: 20",
+          "waterchain.layers.waterchain_grid.data.shape | lookupCulvertShape",
         valueSuffix: "",
         defaultValue: "rechthoekig"
       }
@@ -663,7 +663,7 @@ angular.module('omnibox')
         keyName: "Bediening",
         attrName: "controlled",
         ngBindValue:
-          "waterchain.layers.waterchain_grid.data.controlled",
+          "waterchain.layers.waterchain_grid.data.controlled | lookupWeirControl",
         valueSuffix: "",
         defaultValue: "RTC"
       },

--- a/app/lizard-nxt-filters.js
+++ b/app/lizard-nxt-filters.js
@@ -89,6 +89,94 @@ angular.module('lizard-nxt-filters')
   };
 });
 
+// lookups: culvert
+
+angular.module('lizard-nxt-filters')
+  .filter('lookupCulvertShape', function () {
+  return function (input) {
+    var out;
+    switch (input) {
+    case '0':
+      out = 'rond';
+      break;
+    case '1':
+      out = 'eivorm';
+      break;
+    case '2':
+      out = 'rechthoek';
+      break;
+    case '3':
+      out = 'muilvorm';
+      break;
+    case '4':
+      out = 'vierkant';
+      break;
+    case '5':
+      out = 'heul';
+      break;
+    case '6':
+      out = 'trapezium';
+      break;
+    case '98':
+      out = 'Vorm afwijkend';
+      break;
+    case '99':
+      out = 'Vorm onbekend';
+      break;
+    default:
+      out = 'Vorm afwijkend';
+    }
+    return out;
+  };
+});
+
+angular.module('lizard-nxt-filters')
+  .filter('lookupCulvertMaterial', function () {
+  return function (input) {
+    var out;
+    switch (input) {
+    case '0':
+      out = 'beton';
+      break;
+    case '1':
+      out = 'PVC';
+      break;
+    case '2':
+      out = 'gres';
+      break;
+    default:
+      out = 'Materiaal afwijkend';
+    }
+    return out;
+  };
+});
+
+// lookups: weir
+
+angular.module('lizard-nxt-filters')
+  .filter('lookupWeirControl', function () {
+  return function (input) {
+    var out;
+    switch (input) {
+    case '1':
+      out = '1';
+      break;
+    case '2':
+      out = '2';
+      break;
+    case '3':
+      out = '3';
+      break;
+    case '4':
+      out = '4';
+      break;
+    default:
+      out = 'Niet bekend';
+    }
+    return out;
+  };
+});
+
 
 // lookups: levee
 


### PR DESCRIPTION
### Issue
Some attributes were not translated in front end.

### Fix
Add filters for missing attribute translations.

**NOTE:** waiting for weir controlled attributed translations.

fixes: https://github.com/nens/lizard-nxt/issues/633