### PR TITLE
Add translations for controlled attribute of weir

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,9 @@ Changelog of lizard-nxt client
 
 Unreleased (1.2.7) (XXXX-XX-XX)
 -------------------------------
+
+- Add translations for `controlled` attribute of weir.
+
 - Store selected aggregation for events in time ctx.
 
 - Store selected timeseries and move specific code to directive.

--- a/app/lizard-nxt-filters.js
+++ b/app/lizard-nxt-filters.js
@@ -159,16 +159,19 @@ angular.module('lizard-nxt-filters')
     var out;
     switch (input) {
     case '1':
-      out = '1';
+      out = 'Vast';
       break;
     case '2':
-      out = '2';
+      out = 'Regelbaar, niet auto';
       break;
     case '3':
-      out = '3';
+      out = 'Regelbaar, auto';
       break;
     case '4':
-      out = '4';
+      out = 'Handmatig';
+      break;
+    case '98':
+      out = 'Overig';
       break;
     default:
       out = 'Niet bekend';


### PR DESCRIPTION
### Issue
No translations for controlled attributed of weir.

### Fix
Add translations.