### PR TITLE
Add credentials to ajax calls when on sandbox.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,8 @@ Changelog of lizard-nxt client
 
 Unreleased (1.2.7) (XXXX-XX-XX)
 -------------------------------
--
+
+- Add withCredentials to Restangular for ajax calls when on sandbox.
 
 
 Release 1.2.25 (2015-2-19)

--- a/app/lib/cabinet-service.js
+++ b/app/lib/cabinet-service.js
@@ -18,6 +18,7 @@ angular.module('lizard-nxt')
   if (window.location.host === 'nens.github.io' ||
       window.location.host === 'lizard.sandbox.lizard.net') {
     Restangular.setBaseUrl(backendDomain);
+    Restangular.setDefaultHttpFields({withCredentials: true});
   }
   Restangular.setRequestSuffix('?page_size=0');
   geocodeResource = Restangular.one('api/v1/geocode/');


### PR DESCRIPTION
### Issue
On sandbox, requests from client to server have to send `withCredentials=true` to prevent CORS issues.

### Fix
Add `withCredentials=true` for sandbox Restangular resources.