### PR TITLE
Arjen data availability nonequidistant rasters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog of lizard-nxt client
 Unreleased (1.2.25) (XXXX-XX-XX)
 -------------------------------
 
+- Show tickmarks in timeline for available images for dynamic raster stores.
+
 - Fix tests by staying backwards compatible on layers with no meta object.
 
 - Context aware button to zoom to bounds in layer chooser.

--- a/app/components/timeline/timeline-directives.js
+++ b/app/components/timeline/timeline-directives.js
@@ -218,6 +218,7 @@ angular.module('lizard-nxt')
      * That will change later when we set data.
      */
     var getTimeLineData = function () {
+      console.log("getTimeLineData");
       var timelineLayers = getTimelineLayers(DataService.layerGroups),
           context = {eventOrder: 1,
                      nEvents: scope.events.nEvents};
@@ -352,7 +353,8 @@ angular.module('lizard-nxt')
       RasterService.getData(
         rasterLayer,
         {
-          geom: bounds,
+          //geom: bounds,
+          geom: bounds.getCenter(),
           start: start,
           agg: rasterLayer.aggregationType,
           end: stop,
@@ -375,6 +377,7 @@ angular.module('lizard-nxt')
     };
 
     var timelineZoomHelper = function () {
+      console.log("Timeline zoom helper");
       if (!State.temporal.timelineMoving) {
         if (!timelineSetsTime) {
           State.temporal.aggWindow = UtilService.getAggWindow(

--- a/app/components/timeline/timeline-directives.js
+++ b/app/components/timeline/timeline-directives.js
@@ -255,6 +255,8 @@ angular.module('lizard-nxt')
         angular.forEach(timelineLayers.rasterStore.layers, function (layer) {
           getTemporalRasterDates(layer);
         });
+      } else {
+        timeline.drawTickMarks([]);
       }
 
       updateTimelineHeight(scope.events.nEvents);
@@ -416,7 +418,6 @@ angular.module('lizard-nxt')
      */
     scope.$watch(State.toString('spatial.bounds'), function (n, o) {
       if (n === o) { return true; }
-      console.log("WATCH: spatial watch");
       getTimeLineData();
     });
 
@@ -425,7 +426,6 @@ angular.module('lizard-nxt')
      */
     scope.$watch(State.toString('layerGroups.active'), function (n, o) {
       if (n === o) { return true; }
-      console.log("WATCH: lg active watch");
       getTimeLineData();
     });
 
@@ -443,9 +443,13 @@ angular.module('lizard-nxt')
      * Update aggWindow element when timeState.at changes.
      */
     scope.$watch(State.toString('temporal.at'), function (n, o) {
-      console.log("WATCH: at watch");
+      console.log("WATCH: at watch", State.temporal.playing);
+      // update timeline when time-controller changes temporal.at state
       timeline.drawAggWindow(State.temporal.at, State.temporal.aggWindow);
-      timelineZoomHelper();
+      // if temporal.playing don't get new data for each `temporal.at`
+      if (!State.temporal.playing) {
+        timelineZoomHelper();
+      }
     });
 
     /**

--- a/app/components/timeline/timeline-directives.js
+++ b/app/components/timeline/timeline-directives.js
@@ -321,7 +321,7 @@ angular.module('lizard-nxt')
           agg: rasterLayer.aggregationType,
           aggWindow: State.temporal.aggWindow,
           deferrer: {
-            origin: 'timeline_' + rasterLayer.name,
+            origin: 'timeline_' + rasterLayer.slug,
             deferred: $q.defer()
           }
         }
@@ -340,6 +340,9 @@ angular.module('lizard-nxt')
      * @summary get date array for temporal raster layers.
      * @description  get date array for temporal raster. If it gets a response
      * plots a tickmark in the timeline for every date.
+     *
+     * NOTE: refactor this function with getTemporalRasterData to use
+     * dataService.
      *
      * @param {object} rasterLayer - rasterLayer object.
      */

--- a/app/components/timeline/timeline-directives.js
+++ b/app/components/timeline/timeline-directives.js
@@ -91,7 +91,6 @@ angular.module('lizard-nxt')
           State.temporal.resolution = (
             State.temporal.end - State.temporal.start)
             /  UtilService.getCurrentWidth();
-          console.log("zoom end");
           getTimeLineData();
           State.temporal.timelineMoving = false;
         });
@@ -219,7 +218,8 @@ angular.module('lizard-nxt')
      * That will change later when we set data.
      */
     var getTimeLineData = function () {
-      console.log("getTimeLineData");
+      // NOTE: remember which layers *were* active? So we can do stuff with
+      // turning off data (eg tickmarks).
       var timelineLayers = getTimelineLayers(DataService.layerGroups),
           context = {eventOrder: 1,
                      nEvents: scope.events.nEvents};
@@ -354,7 +354,6 @@ angular.module('lizard-nxt')
       RasterService.getData(
         rasterLayer,
         {
-          //geom: bounds,
           geom: bounds.getCenter(),
           start: start,
           agg: rasterLayer.aggregationType,
@@ -370,15 +369,13 @@ angular.module('lizard-nxt')
       .then(
         function (response) {
           if (response && response !== 'null') {
-            console.log("draw these dates as something in timeline", response);
-            timeline.drawTickMarks(response);
+            timeline.drawTickMarks(response, rasterLayer.slug);
           }
         }
       );
     };
 
     var timelineZoomHelper = function () {
-      console.log("Timeline zoom helper");
       if (!State.temporal.timelineMoving) {
         if (!timelineSetsTime) {
           State.temporal.aggWindow = UtilService.getAggWindow(
@@ -435,7 +432,6 @@ angular.module('lizard-nxt')
      */
     scope.$watch(State.toString('temporal.timelineMoving'), function (n, o) {
       if (n === o) { return true; }
-      console.log("WATCH: moving watch");
       timelineZoomHelper();
     });
 
@@ -443,7 +439,6 @@ angular.module('lizard-nxt')
      * Update aggWindow element when timeState.at changes.
      */
     scope.$watch(State.toString('temporal.at'), function (n, o) {
-      console.log("WATCH: at watch", State.temporal.playing);
       // update timeline when time-controller changes temporal.at state
       timeline.drawAggWindow(State.temporal.at, State.temporal.aggWindow);
       // if temporal.playing don't get new data for each `temporal.at`
@@ -456,7 +451,6 @@ angular.module('lizard-nxt')
      * Round timeState.at when animation stops.
      */
     scope.$watch(State.toString('temporal.playing'), function (n, o) {
-      console.log("WATCH: temporal playing");
       if (n === o || n) { return true; }
       State.temporal.at = UtilService.roundTimestamp(
         State.temporal.at + State.temporal.aggWindow / 2,

--- a/app/components/timeline/timeline-directives.js
+++ b/app/components/timeline/timeline-directives.js
@@ -186,7 +186,7 @@ angular.module('lizard-nxt')
      */
     var getTimelineLayers = function (layerGroups) {
       var timelineLayers = {events: {layers: [], slugs: []},
-                            rasterNonEqui: {layers: []},
+                            rasterStore: {layers: []},
                             rain: undefined};
       angular.forEach(layerGroups, function (layergroup) {
         if (layergroup.isActive()) {
@@ -195,11 +195,12 @@ angular.module('lizard-nxt')
               timelineLayers.events.layers.push(layer);
               timelineLayers.events.slugs.push(layer.slug);
             } else if (layer.format === "Store") {
-              timelineLayers.rasterNonEqui.layers.push(layer);
-            } else if (layer.format === "Store" &&
-                       layer.slug === "rain") {
-              timelineLayers.rain = layer;
-            }
+              if (layer.slug !== "rain") {
+                timelineLayers.rasterStore.layers.push(layer);
+              } else if (layer.slug === "rain") {
+                timelineLayers.rain = layer;
+              }
+           }
           });
         }
       });
@@ -243,7 +244,6 @@ angular.module('lizard-nxt')
         timeline.drawLines(undefined, scope.events.nEvents);
       }
 
-      // raster data (for now only rain)
       if (timelineLayers.rain !== undefined) {
         getTemporalRasterData(timelineLayers.rain,
                               timelineLayers.events.length);
@@ -251,8 +251,8 @@ angular.module('lizard-nxt')
         timeline.removeBars();
       }
 
-      if (timelineLayers.rasterNonEqui.layers.length > 0) {
-        angular.forEach(timelineLayers.rasterNonEqui.layers, function (layer) {
+      if (timelineLayers.rasterStore.layers.length > 0) {
+        angular.forEach(timelineLayers.rasterStore.layers, function (layer) {
           getTemporalRasterDates(layer);
         });
       }
@@ -326,7 +326,6 @@ angular.module('lizard-nxt')
       )
       .then(
         function (response) {
-          console.log(response);
           if (response && response !== 'null') {
             timeline.drawBars(response.data);
           }
@@ -417,7 +416,7 @@ angular.module('lizard-nxt')
      */
     scope.$watch(State.toString('spatial.bounds'), function (n, o) {
       if (n === o) { return true; }
-      console.log("spatial watch");
+      console.log("WATCH: spatial watch");
       getTimeLineData();
     });
 
@@ -426,7 +425,7 @@ angular.module('lizard-nxt')
      */
     scope.$watch(State.toString('layerGroups.active'), function (n, o) {
       if (n === o) { return true; }
-      console.log("lg active watch");
+      console.log("WATCH: lg active watch");
       getTimeLineData();
     });
 
@@ -436,7 +435,7 @@ angular.module('lizard-nxt')
      */
     scope.$watch(State.toString('temporal.timelineMoving'), function (n, o) {
       if (n === o) { return true; }
-      console.log("moving watch");
+      console.log("WATCH: moving watch");
       timelineZoomHelper();
     });
 
@@ -444,7 +443,7 @@ angular.module('lizard-nxt')
      * Update aggWindow element when timeState.at changes.
      */
     scope.$watch(State.toString('temporal.at'), function (n, o) {
-      console.log("at watch");
+      console.log("WATCH: at watch");
       timeline.drawAggWindow(State.temporal.at, State.temporal.aggWindow);
       timelineZoomHelper();
     });
@@ -453,6 +452,7 @@ angular.module('lizard-nxt')
      * Round timeState.at when animation stops.
      */
     scope.$watch(State.toString('temporal.playing'), function (n, o) {
+      console.log("WATCH: temporal playing");
       if (n === o || n) { return true; }
       State.temporal.at = UtilService.roundTimestamp(
         State.temporal.at + State.temporal.aggWindow / 2,

--- a/app/components/timeline/timeline-service.js
+++ b/app/components/timeline/timeline-service.js
@@ -312,8 +312,9 @@ angular.module('lizard-nxt')
     },
 
     drawTickMarks: {
-      value: function(data) {
-        tickmarks = drawTickMarkElements(this._svg, this.dimensions, data);
+      value: function(data, slug) {
+        tickmarks = drawTickMarkElements(
+          this._svg, this.dimensions, data, slug);
       }
     },
 
@@ -507,6 +508,11 @@ angular.module('lizard-nxt')
       .attr('height', height)
       .attr('width', width)
       .attr('id', 'circle-group');
+    // Create group for tickmarks
+    svg.select('g').append('g')
+      .attr('height', height)
+      .attr('width', width)
+      .attr('id', 'tickmark-group');
 
     return svg;
 
@@ -744,7 +750,6 @@ angular.module('lizard-nxt')
   };
 
   var updateTickmarks = function (tickmarks, dimensions) {
-    console.log("update tickmarks");
     var height = Timeline.prototype._getHeight(dimensions);
     tickmarks.attr("x", function (d) { return xScale(d); });
     tickmarks.attr("y", height - 5);
@@ -760,19 +765,19 @@ angular.module('lizard-nxt')
    *
    * @returns {object} d3 selection object with tickmarks for each timestamp.
    */
-  var drawTickMarkElements = function (svg, dimensions, data) {
+  var drawTickMarkElements = function (svg, dimensions, data, slug) {
     var height = Timeline.prototype._getHeight(dimensions);
 
     // setup svg group element to hold rects.
+    console.log(data.length, slug);
     if (data.length > 0) {
 
-      var group = svg.select("g").select("#tickmark-group");
+      var group = svg.select("g").select("#tickmark-group").select("#" + slug);
 
       // if group element doesn't exist yet, create one
       if (!group[0][0]) {
-        group = svg.select("g")
-                      .append("g")
-                      .attr("id", "tickmark-group");
+        group = svg.select("g").select("#tickmark-group").append("g")
+                      .attr("id", slug);
       }
 
       // DATA JOIN
@@ -780,9 +785,9 @@ angular.module('lizard-nxt')
       tickmarks = group.selectAll("rect")
         .data(data, function  (d) { return d; });
 
-    } else if (data.length === 0) {
-      // if no data is defined remove group
-      svg.select("g").select("#tickmark-group")
+    } else if (data.length === 0 && slug === undefined) {
+      // if no data and slugs are defined, remove all groups
+      svg.select("g").select("#tickmark-group").selectAll("g")
         .remove();
 
       return;

--- a/app/components/timeline/timeline-service.js
+++ b/app/components/timeline/timeline-service.js
@@ -769,7 +769,6 @@ angular.module('lizard-nxt')
     var height = Timeline.prototype._getHeight(dimensions);
 
     // setup svg group element to hold rects.
-    console.log(data.length, slug);
     if (data.length > 0) {
 
       var group = svg.select("g").select("#tickmark-group").select("#" + slug);

--- a/app/components/timeline/timeline-service.js
+++ b/app/components/timeline/timeline-service.js
@@ -748,11 +748,8 @@ angular.module('lizard-nxt')
        .attr('height', height);
     }
   };
-
   var updateTickmarks = function (tickmarks, dimensions) {
-    var height = Timeline.prototype._getHeight(dimensions);
     tickmarks.attr("x", function (d) { return xScale(d); });
-    tickmarks.attr("y", height - 5);
   };
 
   /**
@@ -794,8 +791,8 @@ angular.module('lizard-nxt')
 
     // UPDATE
     tickmarks.transition()
-      .delay(Timeline.prototype.transTime)
-      .duration(Timeline.prototype.transTime)
+      //.delay(Timeline.prototype.transTime)
+      //.duration(Timeline.prototype.transTime)
       .attr("y", height - 5)
       .attr("x", function (d) { return xScale(d); } );
 
@@ -803,8 +800,8 @@ angular.module('lizard-nxt')
     tickmarks.enter().append("rect")
       .attr("class", "tickmark")
     .transition()
-      .delay(Timeline.prototype.transTime)
-      .duration(Timeline.prototype.transTime)
+      //.delay(Timeline.prototype.transTime)
+      //.duration(Timeline.prototype.transTime)
       .attr("x", function (d) { return xScale(d); } )
       .attr("y", height - 5)
       .attr("height", 5)

--- a/app/components/timeline/timeline-service.js
+++ b/app/components/timeline/timeline-service.js
@@ -615,7 +615,7 @@ angular.module('lizard-nxt')
       }
 
       if (tickmarks) {
-        updateTickmarks(tickmarks);
+        updateTickmarks(tickmarks, dimensions);
       }
 
       if (zoomFn) {
@@ -744,6 +744,7 @@ angular.module('lizard-nxt')
   };
 
   var updateTickmarks = function (tickmarks, dimensions) {
+    console.log("update tickmarks");
     var height = Timeline.prototype._getHeight(dimensions);
     tickmarks.attr("x", function (d) { return xScale(d); });
     tickmarks.attr("y", height - 5);

--- a/app/components/timeline/timeline-service.js
+++ b/app/components/timeline/timeline-service.js
@@ -729,43 +729,41 @@ angular.module('lizard-nxt')
     }
   };
 
+  /**
+   * @function
+   * TODO: docsttring
+   */
   var drawTickMarkElements = function (svg, dimensions, data) {
 
-    // setup svg container
+    // setup svg group element to hold rects.
     if (data.length > 0) {
-      console.log("draw tickmark elements", data, data.length);
       var group = svg
                     .select("g")
                     .append("g")
                     .attr("id", "tickmark-group");
-      //console.log(group);
       // DATA JOIN
-      // Join new data with old elements, based on the id value.
-      tickmarks = group.selectAll("line")
+      // Join new data with old elements, based on the timestamp.
+      tickmarks = group.selectAll("rect")
         .data(data, function  (d) { return d; });
 
-      console.log(tickmarks);
     } else if (data.length === 0) {
-      // if no data is defined, remove all groups
-      var group_ = svg.select("g").select("#tickmark-group");
-      group_.remove();
+      // if no data is defined remove group
+      svg.select("g").select("#tickmark-group")
+        .remove();
 
       return;
     }
 
-    //tickmarks.append("g");
-    tickmarks.enter().append("line")
-      .attr("class", "tickmar")
-      .attr("stroke", "#000")
-      .attr("stroke-opacity", 0.8)
-      .attr("stroke-width", 5)
+    // ENTER
+    tickmarks.enter().append("rect")
+      .attr("class", "tickmark")
     .transition()
       .delay(Timeline.prototype.transTime)
       .duration(Timeline.prototype.transTime)
-      .attr("x1", function (d) { return xScale(d); } )
-      .attr("x2", function (d) { return xScale(d) + 2; } )
-      .attr("y1", 10)
-      .attr("y2", 10);
+      .attr("x", function (d) { return xScale(d); } )
+      .attr("y", 5)
+      .attr("height", 5)
+      .attr("width", 2);
 
     // EXIT
     // Remove old elements as needed.

--- a/app/components/timeline/timeline-service.js
+++ b/app/components/timeline/timeline-service.js
@@ -39,7 +39,8 @@ angular.module('lizard-nxt')
   futureIndicator,
   aggWindow, // aggregation window
   lines, // events start - end
-  bars; // rain intensity
+  bars, // rain intensity
+  tickmarks; // data availability indicators
 
   /**
    * @constructor
@@ -299,6 +300,12 @@ angular.module('lizard-nxt')
           slug,
           color
         );
+      }
+    },
+
+    drawTickMarks: {
+      value: function(data) {
+        tickmarks = drawTickMarkElements(this._svg, this.dimensions, data);
       }
     },
 
@@ -720,6 +727,60 @@ angular.module('lizard-nxt')
        .duration(Timeline.prototype.transTime)
        .attr('height', height);
     }
+  };
+
+  var drawTickMarkElements = function (svg, dimensions, data) {
+
+    // setup svg container
+    if (data.length > 0) {
+      console.log("draw tickmark elements", data, data.length);
+      var group = svg
+                    .select("g")
+                    .append("g")
+                    .attr("id", "tickmark-group");
+      //console.log(group);
+      // DATA JOIN
+      // Join new data with old elements, based on the id value.
+      tickmarks = group.selectAll("line")
+        .data(data, function  (d) { return d; });
+
+      console.log(tickmarks);
+    } else if (data.length === 0) {
+      // if no data is defined, remove all groups
+      var group_ = svg.select("g").select("#tickmark-group");
+      group_.remove();
+
+      return;
+    }
+
+    //tickmarks.append("g");
+    tickmarks.enter().append("line")
+      .attr("class", "tickmar")
+      .attr("stroke", "#000")
+      .attr("stroke-opacity", 0.8)
+      .attr("stroke-width", 5)
+    .transition()
+      .delay(Timeline.prototype.transTime)
+      .duration(Timeline.prototype.transTime)
+      .attr("x1", function (d) { return xScale(d); } )
+      .attr("x2", function (d) { return xScale(d) + 2; } )
+      .attr("y1", 10)
+      .attr("y2", 10);
+
+    // EXIT
+    // Remove old elements as needed.
+    tickmarks.exit()
+      .transition()
+      .delay(0)
+      .duration(Timeline.prototype.transTime)
+    .transition()
+      .delay(Timeline.prototype.transTime)
+      .duration(Timeline.prototype.transTime)
+      .attr("stroke-width", 0)
+      .remove();
+
+    return tickmarks;
+
   };
 
   /**

--- a/app/components/timeline/timeline-service.js
+++ b/app/components/timeline/timeline-service.js
@@ -791,8 +791,8 @@ angular.module('lizard-nxt')
 
     // UPDATE
     tickmarks.transition()
-      //.delay(Timeline.prototype.transTime)
-      //.duration(Timeline.prototype.transTime)
+      .delay(Timeline.prototype.transTime)
+      .duration(Timeline.prototype.transTime)
       .attr("y", height - 5)
       .attr("x", function (d) { return xScale(d); } );
 
@@ -800,8 +800,8 @@ angular.module('lizard-nxt')
     tickmarks.enter().append("rect")
       .attr("class", "tickmark")
     .transition()
-      //.delay(Timeline.prototype.transTime)
-      //.duration(Timeline.prototype.transTime)
+      .delay(Timeline.prototype.transTime)
+      .duration(Timeline.prototype.transTime)
       .attr("x", function (d) { return xScale(d); } )
       .attr("y", height - 5)
       .attr("height", 5)

--- a/app/lib/raster-service.js
+++ b/app/lib/raster-service.js
@@ -52,7 +52,7 @@ angular.module('lizard-nxt')
       canceler = cancelers[layer.slug] = $q.defer();
     }
 
-    return CabinetService.raster(canceler).get({
+    var requestOptions = {
       raster_names: layer.slug,
       geom: wkt,
       srs: srs,
@@ -61,7 +61,13 @@ angular.module('lizard-nxt')
       agg: agg,
       styles: options.styles,
       window: aggWindow
-    });
+    };
+
+    if (options.truncate === true) {
+      requestOptions['truncate'] = options.truncate;
+    }
+
+    return CabinetService.raster(canceler).get(requestOptions);
   };
 
   /**

--- a/app/styles/_colors.scss
+++ b/app/styles/_colors.scss
@@ -16,3 +16,4 @@ $silver: #bdc3c7; // medium-light grey
 $turquoise: #1abc9c; // Blue/Greenish
 $white1: #fbfbfb;
 $white: #ffffff;
+$bargrey: #95a5a6;

--- a/app/styles/_graph.scss
+++ b/app/styles/_graph.scss
@@ -62,6 +62,13 @@ rect.bar {
   stroke: white;
 }
 
+.tickmark {
+  fill: black;
+  stroke-width: 1;
+  fill-opacity: 0.8;
+  stroke: black;
+}
+
 .y1.axis  text {
   fill: crimson;
   stroke: none;

--- a/app/styles/_graph.scss
+++ b/app/styles/_graph.scss
@@ -10,7 +10,7 @@
 
 .axis path, .axis line {
     fill: none;
-    stroke: #bdc3c7;
+    stroke: $silver;
     shape-rendering: crispEdges;
     stroke-width: 2;
 }
@@ -43,7 +43,7 @@
 }
 
 rect {
-fill: #95a5a6;
+fill: $bargrey;
 }
 
 #listeners {
@@ -52,21 +52,21 @@ fill: #95a5a6;
 
 rect.bar {
   stroke: white;
-  fill: #95a5a6;
+  fill: $bargrey;
 }
 
 .bar-timeline {
-  fill: #95a5a6;
+  fill: $bargrey;
   stroke-width: 1;
   fill-opacity: 1;
   stroke: white;
 }
 
 .tickmark {
-  fill: black;
+  fill: $midnightblue;
   stroke-width: 1;
-  fill-opacity: 0.8;
-  stroke: black;
+  fill-opacity: 1;
+  stroke: $midnightblue;
 }
 
 .y1.axis  text {
@@ -76,13 +76,13 @@ rect.bar {
 }
 
 text, axis text {
-  fill: #bdc3c7;
+  fill: $silver;
   stroke: none;
   font-size: 13px;
 }
 
 .graph-text {
-  fill: #bdc3c7;
+  fill: $silver;
   stroke: none;
   font-size: 13px;
 }
@@ -138,7 +138,7 @@ text.d3tooltip:after {
   margin-top: -136px;
   opacity: 0.0;
   text-align: center;
-  color: #7f8c8d;
+  color: $asbestos;
   font-weight: 800;
   font-size: 40px;
   padding-top: 15px;
@@ -146,7 +146,7 @@ text.d3tooltip:after {
 
 .donut-title-text {
   text-anchor: middle;
-  fill: #7f8c8d;
+  fill: $asbestos;
   font-size: 14px;
   font-family: 'Roboto', Helvetica, Arial, sans-serif;
 }


### PR DESCRIPTION
### Issue
We want to be able to indicated the availability of raster (store) data in the timeline.

### Fix
Request truncated data from raster-store and plot returned array of datetimes in timeline as tickmarks.

**NOTE:** one bug left where tickmarks are not cleaned when more than 1 layer is active and a layer is deactivated. Will fix in new ticket.