### PR TITLE
fixes https://github.com/nens/lizard-nxt/issues/782 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog of lizard-nxt client
 Unreleased (1.2.25) (XXXX-XX-XX)
 -------------------------------
 
+- Fix position aggregate events in timeline.
+
 - Fixed event count disparity.
 
 - Dynamic axis labels for area.

--- a/app/components/time-ctx/time-ctx-directive.js
+++ b/app/components/time-ctx/time-ctx-directive.js
@@ -68,7 +68,6 @@ angular.module('time-ctx')
       });
 
       scope.tctx.content[response.layerSlug] = item;
-      console.log(item);
     };
 
     var putEventDataOnScope = function (response) {

--- a/app/components/time-ctx/time-ctx-directive.js
+++ b/app/components/time-ctx/time-ctx-directive.js
@@ -68,6 +68,7 @@ angular.module('time-ctx')
       });
 
       scope.tctx.content[response.layerSlug] = item;
+      console.log(item);
     };
 
     var putEventDataOnScope = function (response) {

--- a/app/components/timeline/timeline-service.js
+++ b/app/components/timeline/timeline-service.js
@@ -845,7 +845,7 @@ angular.module('lizard-nxt')
         MAX_COUNT = 100;
 
     var xOneFunction = function (d) {
-      return xScale(parseFloat(d.timestamp) + (aggWindow / 2));
+      return xScale(parseFloat(d.timestamp) - (aggWindow / 2));
     };
 
     var yFunction = function (d) { return yScale(order); };

--- a/app/lib/event-aggregate-service.js
+++ b/app/lib/event-aggregate-service.js
@@ -178,7 +178,7 @@ angular.module('lizard-nxt')
         nestedData
           .forEach(function (timestamp, value) {
             var tmpObj = {
-              timestamp: timestamp,
+              timestamp: Number(timestamp) + aggWindow,
               count: value.count
             };
             aggregatedArray.push(tmpObj);
@@ -206,7 +206,7 @@ angular.module('lizard-nxt')
           .forEach(function (timestamp, value) {
             var tmpObj;
             value.forEach(function (category, value) {
-              tmpObj = {timestamp: timestamp,
+              tmpObj = {timestamp: Number(timestamp) + aggWindow,
                         category: category,
                         mean_duration: value.mean_duration,
                         color: _getColor(category,
@@ -243,7 +243,7 @@ angular.module('lizard-nxt')
           .forEach(function (timestamp, value) {
             var tmpObj = {
               color: baseColor,
-              timestamp: timestamp,
+              timestamp: Number(timestamp) + aggWindow,
               mean_duration: value.mean_duration,
               min: value.min,
               max: value.max,


### PR DESCRIPTION
bars are drawn behind the specified x value. X-values should describe the right of the aggWindow. This corresponds with the raster store response.