### PR TITLE
Fix not passing argument to announceMovedTimeline

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,8 @@ Changelog of lizard-nxt client
 
 Unreleased (1.2.25) (XXXX-XX-XX)
 -------------------------------
--
+
+- Fix undefined announMovedTimeline in time-controller doesn't pass argument.
 
 
 Release 1.3.3 (2015-3-26)

--- a/app/components/timeline/time-controller.js
+++ b/app/components/timeline/time-controller.js
@@ -280,7 +280,7 @@ angular.module('lizard-nxt')
                                     UtilService.MAX_TIME);
       State.temporal.resolution = newResolution;
 
-      UtilService.announceMovedTimeline();
+      UtilService.announceMovedTimeline(State);
 
     };
 


### PR DESCRIPTION
### Issue
Refactored announceMovedTimeline function in UtilService needs to be passed `State` as argument, which time-controller didn't do

### Fix
Pass `State` as argument.