### PR TITLE
Bigger default timeline height; decrease max radius events in timeline

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ Unreleased (1.2.25) (XXXX-XX-XX)
 
 - Fix undefined announMovedTimeline in time-controller doesn't pass argument.
 
+- Increase default height of timeline from 30 to 45 pixels.
+
+- Decrease maximum event radius in timeline to prevent clipping.
+
 
 Release 1.3.3 (2015-3-26)
 ---------------------

--- a/app/components/timeline/timeline-directives.js
+++ b/app/components/timeline/timeline-directives.js
@@ -38,7 +38,7 @@ angular.module('lizard-nxt')
 
         dimensions = {
           width: UtilService.getCurrentWidth(),
-          height: 30,
+          height: 45,
           events: 25,
           bars: 35,
           padding: {

--- a/app/components/timeline/timeline-service.js
+++ b/app/components/timeline/timeline-service.js
@@ -841,7 +841,7 @@ angular.module('lizard-nxt')
     svg, dimensions, xScale, yScale, data, order, slug, color, aggWindow) {
 
     var MIN_CIRCLE_SIZE = 3,
-        MAX_CIRCLE_SIZE = 18,
+        MAX_CIRCLE_SIZE = 16,
         MAX_COUNT = 100;
 
     var xOneFunction = function (d) {


### PR DESCRIPTION
### Issue 1
Default timeline height too small.

### Fix 1
Increase default timeline height.

### Issue 2
Event circles in timeline got clipped at max event circle size.

### Fix 2
Decrease max event circle size.