### PR TITLE
Export timeseries as CSV

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -9,16 +9,16 @@
 
     "globals": {
         "$": false,
-        "jasmine": false,
-        "it": false,
-        "describe": false,
-        "expect": false,
-        "beforeEach": false,
-        "afterEach": false,
+        "jasmine": true,
+        "it": true,
+        "describe": true,
+        "expect": true,
+        "beforeEach": true,
+        "afterEach": true,
         "spyOn": false,
         "runs": false,
-        "module": false,
-        "inject": false
+        "module": true,
+        "inject": true
     },
 
     "node"          : true,

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog of lizard-nxt client
 Unreleased (1.2.25) (XXXX-XX-XX)
 -------------------------------
 
+- Export timeseries as CSV for data in browser.
+
 - Fix flipping of start and end date on page reload.
 
 - Dynamic y-value per event and give events enough space for the whole radius

--- a/app/components/omnibox/controllers/point-controller.js
+++ b/app/components/omnibox/controllers/point-controller.js
@@ -13,6 +13,7 @@
 
 angular.module('omnibox')
 .controller('PointCtrl', [
+
   '$scope',
   '$q',
   'LeafletService',
@@ -22,7 +23,16 @@ angular.module('omnibox')
   'DataService',
   'State',
 
-  function ($scope, $q, LeafletService, ClickFeedbackService, UtilService, MapService, DataService, State) {
+  function (
+    $scope,
+    $q,
+    LeafletService,
+    ClickFeedbackService,
+    UtilService,
+    MapService,
+    DataService,
+    State
+  ) {
 
     var GRAPH_WIDTH = 600;
     $scope.box.content = {};
@@ -47,8 +57,10 @@ angular.module('omnibox')
       promise.then(drawFeedback, null, function (response) {
         if (response && response.data) {
           // If we deal with raster data....
-          if (response.layerSlug === 'rain' && response.data && response.data.data !== null) {
-            if ($scope.box.content[response.layerGroupSlug] === undefined) { return; }
+          if (response.layerSlug === 'rain' &&
+              response.data && response.data.data !== null) {
+            if ($scope.box.content[
+                  response.layerGroupSlug] === undefined) { return; }
             if (!$scope.box.content[response.layerGroupSlug].layers.hasOwnProperty(response.layerSlug)) { return; }
 
             // This could probably be different..
@@ -142,6 +154,11 @@ angular.module('omnibox')
           coordinates: [State.spatial.here.lng, State.spatial.here.lat]
         });
       }
+    };
+
+    // CSV formatter
+    $scope.formatCSVColumns = function (data) {
+      return UtilService.formatCSVColumns(data, State.spatial.here);
     };
 
     // Update when user clicked again

--- a/app/components/omnibox/controllers/rain-controller.js
+++ b/app/components/omnibox/controllers/rain-controller.js
@@ -33,7 +33,8 @@ angular.module('omnibox')
         if (!$scope.$$phase) {
           $scope.$apply(function () {
             $scope.rrc.active = !$scope.rrc.active;
-            $scope.lg.layers['rain'].changed = !$scope.lg.layers['rain'].changed;
+            $scope.lg.layers['rain'].changed =
+             !$scope.lg.layers['rain'].changed;
           });
         } else {
           $scope.rrc.active = !$scope.rrc.active;
@@ -61,46 +62,5 @@ angular.module('omnibox')
           $scope.rrc.data = response;
         });
       };
-
-      /**
-       * Format the CSV (exporting rain data for a point in space/interval in
-       * time) in a way that makes it comprehensible for les autres.
-       *
-       */
-      $scope.formatCSVColumns = function (data) {
-        var i,
-            formattedDateTime,
-            formattedData = [],
-            lat = State.spatial.here.lat,
-            lng = State.spatial.here.lng,
-            _formatDate = function (epoch) {
-              var d = new Date(parseInt(epoch, 10));
-              return [
-                [d.getDate(), d.getMonth() + 1, d.getFullYear()].join('-'),
-                [d.getHours() || "00", d.getMinutes() || "00", d.getSeconds() || "00"].join(':')
-              ];
-            };
-
-        for (i = 0; i < data.length; i++) {
-
-          formattedDateTime = _formatDate(data[i][0]);
-
-          formattedData.push([
-            formattedDateTime[0],
-            formattedDateTime[1],
-            UtilService.formatNumber(
-              Math.floor(100 * data[i][1]) / 100 || 0,
-              0,
-              2,
-              true // Dutchify seperators
-            ),
-            UtilService.formatNumber(lat, 0, 0, true),
-            UtilService.formatNumber(lng, 0, 0, true)
-          ]);
-        }
-
-        return formattedData;
-      };
-
     }
 ]);

--- a/app/components/omnibox/templates/rain.html
+++ b/app/components/omnibox/templates/rain.html
@@ -26,7 +26,7 @@
          <a
            class="btn btn-default btn-xs"
            title="Data van deze infocard exporteren"
-           ng-csv="formatCSVColumns(lg.layers['rain'].data)"
+           ng-csv="$parent.formatCSVColumns(lg.layers['rain'].data)"
            filename="neerslag.csv"
            csv-header="['Datestamp', 'Timestamp', 'Rain (mm)', 'Latitude', 'Longitude']" >
            <i class="fa fa-share-square-o"></i>

--- a/app/components/omnibox/templates/timeseries.html
+++ b/app/components/omnibox/templates/timeseries.html
@@ -49,6 +49,19 @@
       now="timeState.at">
     </graph>
   </div>
+
+   <div class="card-tools">
+     <a
+       class="btn btn-default btn-xs"
+       title="Data van deze infocard exporteren"
+       ng-csv="$parent.formatCSVColumns(timeseries.selectedTimeseries.events)"
+       filename="<% timeseries.selectedTimeseries.name %>.csv"
+       csv-header="['Datestamp', 'Timestamp', timeseries.selectedTimeseries.unit, 'Latitude', 'Longitude']" >
+       <i class="fa fa-share-square-o"></i>
+       Exporteer
+     </a>
+   </div>
+
 </div>
 
 

--- a/app/lib/util-service.js
+++ b/app/lib/util-service.js
@@ -702,6 +702,7 @@ angular.module('lizard-nxt')
   };
 
   /**
+   * @function
    * @description - "%f-in-javascript", you know the drill
    *
    * @param {number} x - The input you want to convert
@@ -751,6 +752,59 @@ angular.module('lizard-nxt')
       0, // no delay, fire when digest ends
       true // trigger new digest loop
     );
+  };
+
+  /**
+   * @function _formatDate
+   * @summmary Format epoch in ms to human readable string.
+   * @description Format epoch in ms to human readable string.
+   *
+   * @param {integer} epoch - time in ms since 1970.
+   * @returns {string} formatted date.
+   */
+  this._formatDate = function (epoch) {
+    var d = new Date(parseInt(epoch, 10));
+    return [
+      [d.getDate(), d.getMonth() + 1,
+       d.getFullYear()].join('-'),
+      [d.getHours() || "00",
+       d.getMinutes() || "00",
+       d.getSeconds() || "00"].join(':')
+    ];
+  };
+
+  /**
+   * Format CSV (exporting rain data for a point in space/interval in
+   * time) in a way that makes it comprehensible for les autres.
+   *
+   * @param {object []} data - list with data objects to parse.
+   * @param {object} latLng - latlng object with location of data.
+   * @returns list of formatted data objects.
+   */
+  this.formatCSVColumns = function (data, latLng) {
+    var i,
+        formattedDateTime,
+        formattedData = [];
+
+    for (i = 0; i < data.length; i++) {
+
+      formattedDateTime = this._formatDate(data[i][0]);
+
+      formattedData.push([
+        formattedDateTime[0],
+        formattedDateTime[1],
+        this.formatNumber(
+          Math.floor(100 * data[i][1]) / 100 || 0,
+          0,
+          2,
+          true // Dutchify seperators
+        ),
+        this.formatNumber(latLng.lat, 0, 0, true),
+        this.formatNumber(latLng.lng, 0, 0, true)
+      ]);
+    }
+
+    return formattedData;
   };
 
 }]);

--- a/test/spec/util-service.js
+++ b/test/spec/util-service.js
@@ -1,11 +1,7 @@
 // event-aggregate-service-tests.js
 
-describe('Testing event aggregate service', function () {
-  var $scope, $rootScope, UtilService, timeState;
-
-  timeState = {
-    'aggWindow': 3600000
-  };
+describe('Testing util-service functions', function () {
+  var $scope, $rootScope, UtilService;
 
   beforeEach(module('lizard-nxt'));
 
@@ -26,4 +22,53 @@ describe('Testing event aggregate service', function () {
     expect(result).toBe("#ff0000");
   });
 
+  it("Should return a list formatted data for a list raw input data",
+      function () {
+
+    var inputData = [[1420070400000, 0.58], [1420149600000, 8.2354]],
+        latLng = {lat: 52.7, lng: 5.2},
+        expectedResult = [[ '1-1-2015', '1:00:00', '0,57', '52,7', '5,2' ],
+                          [ '1-1-2015', '23:00:00', '8,23', '52,7', '5,2' ]];
+
+    var result = UtilService.formatCSVColumns(inputData, latLng);
+    expect(result).toEqual(expectedResult);
+  });
+
+  it("Should return a list with formatted date and timestamp for an" +
+     " epoch timestamp in ms", function () {
+
+    var epoch = 1420070400000,
+        expectedResult = ['1-1-2015', '1:00:00'];
+
+    var result = UtilService._formatDate(epoch);
+    expect(result).toEqual(expectedResult);
+  });
+
+  it("Should return a formatted number for a raw number", function () {
+
+    var number = 3.872,
+        leadingDigits = 3,
+        trailingDigits = 4,
+        expectedResult = '003.8720';
+
+    var result = UtilService.formatNumber(number,
+                                          leadingDigits,
+                                          trailingDigits);
+    expect(result).toEqual(expectedResult);
+  });
+
+  it("Should return a Dutchified formatted number for a raw number",
+      function () {
+
+    var number = 3.872,
+        leadingDigits = 3,
+        trailingDigits = 4,
+        expectedResult = '003,8720';
+
+    var result = UtilService.formatNumber(number,
+                                          leadingDigits,
+                                          trailingDigits,
+                                          true);
+    expect(result).toEqual(expectedResult);
+  });
 });


### PR DESCRIPTION
### Issue
Customers wants to be able to download timeseries as CSV, the same way as rain data.

### Solution
Add export button for timeseries omnibox like for rain. Therefore, move rain specific `formatCSVColumns` function from rain controller to util-service and refactor so both rain and timeseries omnibox cards can use the function.

**NOTE:** update jshintrc not to fail for jasmine keywords.