### PR TITLE
enable use of d3.area for graphs that have y0 and y1 in keys

### DIFF
--- a/app/components/data-menu/services/data-service.js
+++ b/app/components/data-menu/services/data-service.js
@@ -291,6 +291,7 @@ angular.module('data-menu')
             response.data.entity_name + '$' + response.data.id,
             options.start,
             options.end,
+            options.minPoints,
             defer
           );
           // The defer from getData is recycled, no need to pass a callee param.
@@ -311,15 +312,25 @@ angular.module('data-menu')
        * @memberOf app.pointCtrl
        * @description gets timeseries from service
        */
-      var getTimeSeriesForObject = function (objectId, start, end, defer) {
+      var getTimeSeriesForObject = function (
+          objectId,
+          start,
+          end,
+          minPoints,
+          defer
+        ) {
 
         // maximum number of timeseries events, more probably results in a
         // memory error.
         var MAX_NR_TIMESERIES_EVENTS = 25000;
-        var promise = TimeseriesService.getTimeseries(objectId, {
-          start: start,
-          end: end
-        }).then(function (response) {
+        var promise = TimeseriesService.getTimeseries(
+          objectId,
+          {
+            start: start,
+            end: end
+          },
+          minPoints
+        ).then(function (response) {
 
            // Filter out the timeseries with too little measurements.
           var filteredResult = [];

--- a/app/components/graph/graph-service.js
+++ b/app/components/graph/graph-service.js
@@ -130,8 +130,18 @@ angular.module('lizard-nxt')
           this._xy = rescale(this._svg, this.dimensions, this._xy, data, keys, null, this._xDomainInfo);
           drawLabel(this._svg, this.dimensions, labels.y, true);
         }
-        var line = this._createLine(this._xy, keys);
-        this._path = drawPath(this._svg, line, data, this.transTime, this._path);
+
+        var pathFn = keys.y.hasOwnProperty('y0') && keys.y.hasOwnProperty('y1')
+          ? this._createArea(this._xy, keys)
+          : this._createLine(this._xy, keys);
+
+        this._path = drawPath(
+          this._svg,
+          pathFn,
+          data,
+          this.transTime,
+          this._path
+        );
 
         if (this.dimensions.width > MIN_WIDTH_INTERACTIVE_GRAPHS) {
           addInteractionToPath(
@@ -346,14 +356,13 @@ angular.module('lizard-nxt')
           };
         }
         var xy = {x: {}, y: {}};
-        var self = this;
 
         angular.forEach(xy, function (value, key) {
           var y = key === 'y';
-          xy[key] = self._createD3Objects(data, keys[key], options[key], y);
-          drawAxes(self._svg, xy[key].axis, self.dimensions, y);
-          drawLabel(self._svg, self.dimensions, labels[key], y);
-        });
+          xy[key] = this._createD3Objects(data, keys[key], options[key], y);
+          drawAxes(this._svg, xy[key].axis, this.dimensions, y);
+          drawLabel(this._svg, this.dimensions, labels[key], y);
+        }, this);
         return xy;
       }
     }
@@ -680,8 +689,7 @@ angular.module('lizard-nxt')
       // bring to front
       fg.node().parentNode.appendChild(fg.node());
       path = fg.append("svg:path")
-        .attr("class", "line")
-        .style("stroke-width", 3);
+        .attr("class", "line");
     }
     path.datum(data)
       .transition()

--- a/app/components/omnibox/controllers/point-controller.js
+++ b/app/components/omnibox/controllers/point-controller.js
@@ -50,7 +50,8 @@ angular.module('omnibox')
         geom: here,
         start: State.temporal.start,
         end: State.temporal.end,
-        aggWindow: aggWindow
+        aggWindow: aggWindow,
+        minPoints: 320 // Width of drawing area of box graphs.
       });
 
       // Draw feedback when all promises resolved

--- a/app/components/omnibox/templates/timeseries.html
+++ b/app/components/omnibox/templates/timeseries.html
@@ -30,7 +30,10 @@
         data="timeseries.selectedTimeseries.events"
         ylabel="timeseries.selectedTimeseries.unit"
         xlabel=""
-        keys="{x: 0, y: 1}"
+        keys="{
+          x: 'timestamp',
+          y: { 'y0': 'min', 'y1': 'max' }
+        }"
         now="timeState.at">
       </graph>
   </div>
@@ -45,7 +48,10 @@
       data="timeseries.selectedTimeseries.events"
       ylabel="timeseries.selectedTimeseries.unit"
       xlabel=""
-      keys="{x: 0, y: 1}"
+      keys="{
+        x: 'timestamp',
+        y: { 'y0': 'min', 'y1': 'max' }
+      }"
       now="timeState.at">
     </graph>
   </div>

--- a/app/components/omnibox/templates/timeseries.html
+++ b/app/components/omnibox/templates/timeseries.html
@@ -22,7 +22,7 @@
 
   <div class="timeseries-graph-container"
       ng-class="{hidden: !fullDetails}"
-      ng-show="$parent.box.content.waterchain.layers.waterchain_grid.data.entity_name === 'measuringstation'">
+      ng-if="$parent.box.content.waterchain.layers.waterchain_grid.data.entity_name === 'measuringstation'">
      <graph
         bar-chart
         type="temporal"
@@ -31,8 +31,8 @@
         ylabel="timeseries.selectedTimeseries.unit"
         xlabel=""
         keys="{
-          x: 'timestamp',
-          y: { 'y0': 'min', 'y1': 'max' }
+          x: 0,
+          y: 1
         }"
         now="timeState.at">
       </graph>
@@ -40,7 +40,7 @@
 
   <div class="timeseries-graph-container"
     ng-class="{hidden: !fullDetails}"
-    ng-show="$parent.box.content.waterchain.layers.waterchain_grid.data.entity_name !== 'measuringstation'">
+    ng-if="$parent.box.content.waterchain.layers.waterchain_grid.data.entity_name !== 'measuringstation'">
     <graph
       line
       type="temporal"

--- a/app/components/time-ctx/time-ctx-directive.js
+++ b/app/components/time-ctx/time-ctx-directive.js
@@ -71,7 +71,6 @@ angular.module('time-ctx')
       angular.forEach(sharedKeys, function (key) {
         item[key] = response[key];
       });
-
       scope.tctx.content[response.layerSlug] = item;
     };
 
@@ -135,6 +134,7 @@ angular.module('time-ctx')
         } else if (response.layerSlug === 'timeseries') {
           angular.forEach(response.data, function (ts) {
             ts.layerSlug = ts.name;
+            ts.type = response.layerSlug;
             putDataOnScope(ts);
           });
         } else {

--- a/app/components/time-ctx/time-ctx-directive.js
+++ b/app/components/time-ctx/time-ctx-directive.js
@@ -40,8 +40,6 @@ angular.module('time-ctx')
         + GRAPH_5_6th_PADDING_RATIO * UtilService.TIMELINE_LEFT_MARGIN;
     };
 
-    Timeline.onresize = resize;
-
     scope.tctx.dims = {
       width: UtilService.getCurrentWidth()
         + GRAPH_5_6th_PADDING_RATIO * UtilService.TIMELINE_LEFT_MARGIN,
@@ -109,10 +107,15 @@ angular.module('time-ctx')
         : State.spatial.here;
 
     var getTimeData = function () {
+      var graphWidth = scope.tctx.dims.width -
+        scope.tctx.dims.padding.left -
+        scope.tctx.dims.padding.right;
+
       DataService.getData('time', {
         geom: geom,
         start: State.temporal.start,
         end: State.temporal.end,
+        minPoints: graphWidth,
         temporalOnly: true // TODO: actually implement this in data-service.
       }).then(null, null, function (response) {
 
@@ -161,7 +164,10 @@ angular.module('time-ctx')
 
     var applyResize = function () {
       scope.$apply(resize(tlDims));
+      getTimeData();
     };
+
+    Timeline.onresize = resize;
 
     window.addEventListener('resize', applyResize);
 

--- a/app/components/time-ctx/time-ctx.html
+++ b/app/components/time-ctx/time-ctx.html
@@ -11,7 +11,7 @@
       <div class="dashboard-inner">
 
         <graph
-          ng-if="item.scale !== 'ratio' && item.type !== 'Event'"
+          ng-if="item.type === 'timeseries'"
           line
           data="item.data"
           dimensions="tctx.dims"
@@ -22,19 +22,21 @@
             x: 'timestamp',
             y: { 'y0': 'min', 'y1': 'max' }
           }"
-          name="<% item.name || item.quantity %>">
+          name="<% item.name %>">
         </graph>
 
         <graph
-          ng-if="item.scale === 'ratio'"
-          bar-chart
+          ng-if="item.type !== 'timeseries'
+            && item.scale !== 'ratio'
+            && item.type !== 'Event'"
+          line
           data="item.data"
           dimensions="tctx.dims"
           type="temporal"
           temporal="tctx.state.temporal"
           ylabel="item.unit"
           keys="{x: 0, y: 1}"
-          name="<% item.name || item.quantity %>">
+          name="<% item.quantity %>">
         </graph>
 
         <graph
@@ -48,7 +50,19 @@
                  category: 'category'}"
           dimensions="tctx.dims"
           temporal="tctx.state.temporal"
-          name="<% item.name || item.quantity %>">
+          name="<% item.quantity %>">
+        </graph>
+
+        <graph
+          ng-if="item.scale === 'ratio'"
+          bar-chart
+          data="item.data"
+          dimensions="tctx.dims"
+          type="temporal"
+          temporal="tctx.state.temporal"
+          ylabel="item.unit"
+          keys="{x: 0, y: 1}"
+          name="<% item.quantity %>">
         </graph>
 
       </div>

--- a/app/components/time-ctx/time-ctx.html
+++ b/app/components/time-ctx/time-ctx.html
@@ -18,7 +18,10 @@
           type="temporal"
           temporal="tctx.state.temporal"
           ylabel="item.unit"
-          keys="{x: 0, y: 1}"
+          keys="{
+            x: 'timestamp',
+            y: { 'y0': 'min', 'y1': 'max' }
+          }"
           name="<% item.name || item.quantity %>">
         </graph>
 

--- a/app/lib/nxt-d3-service.js
+++ b/app/lib/nxt-d3-service.js
@@ -389,6 +389,7 @@ angular.module('lizard-nxt')
      * @return {object} d3 path generator for line.
      */
     _createLine: function (xy, keys) {
+      console.info(keys, xy);
       return createPathGenerator(d3.svg.line)
         .y(function (d) { return xy.y.scale(d[keys.y]); })
         .x(function (d) { return xy.x.scale(d[keys.x]); })
@@ -508,6 +509,11 @@ angular.module('lizard-nxt')
       .attr("transform", "translate(0 ," + transform + ")");
   };
 
+  /**
+   * Returns a d3 path with 'monotone' interpolator.
+   * @param  {object} d3Generator d3 [line|area] generator function.
+   * @return {object}             d3 path generator.
+   */
   createPathGenerator = function (d3Generator) {
     // Monotone line goes through all datapoints. Other options are 'basis'
     // which looks nice but can give inaccurate results, or 'cardinal' which

--- a/app/lib/nxt-d3-service.js
+++ b/app/lib/nxt-d3-service.js
@@ -389,7 +389,6 @@ angular.module('lizard-nxt')
      * @return {object} d3 path generator for line.
      */
     _createLine: function (xy, keys) {
-      console.info(keys, xy);
       return createPathGenerator(d3.svg.line)
         .y(function (d) { return xy.y.scale(d[keys.y]); })
         .x(function (d) { return xy.x.scale(d[keys.x]); })

--- a/app/lib/nxt-d3-service.js
+++ b/app/lib/nxt-d3-service.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * @name NxtD3
  * @class angular.module('lizard-nxt')
@@ -14,7 +16,7 @@
 angular.module('lizard-nxt')
   .factory("NxtD3", [function () {
 
-  var createCanvas, createElementForAxis, resizeCanvas;
+  var createCanvas, createElementForAxis, resizeCanvas, createPathGenerator;
 
   /**
    * @constructor
@@ -195,16 +197,27 @@ angular.module('lizard-nxt')
         return {max: null, min: null};
       }
 
-      // min max of d3 filters nulls but not if you cast null into 0. Only cast
-      // strings, and array like [0, [3]].
-      var comparator = function (d) {
-        return typeof(d[key]) === 'string' || d[key] instanceof Array
-          ? Number(d[key])
-          : d[key];
-      };
+      var min, max;
 
-      var max = d3.max(data, comparator);
-      var min = d3.min(data, comparator);
+      if (key.hasOwnProperty('y0') && key.hasOwnProperty('y1')) {
+        var minComparator = function (d) { return d[key.y0]; };
+        min = d3.min(data, minComparator);
+
+        var maxComparator = function (d) { return d[key.y1]; };
+        max = d3.max(data, maxComparator);
+      }
+
+      else {
+        // min max of d3 filters nulls but not if you cast null into 0. Only cast
+        // strings, and array like [0, [3]].
+        var comparator = function (d) {
+          return typeof(d[key]) === 'string' || d[key] instanceof Array
+            ? Number(d[key])
+            : d[key];
+        };
+        max = d3.max(data, comparator);
+        min = d3.min(data, comparator);
+      }
 
       return {
         max: max,
@@ -368,27 +381,42 @@ angular.module('lizard-nxt')
 
     /**
      * @function
-     * @memberOf angular.module('lizard-nxt')
-  .NxtD3
+     * @memberOf angular.module('lizard-nxt').NxtD3
      *
      * @param {object} xy object containing y.scales and x.scale.
      * @param {object} keys object containing y.key and x.key.
      * @description returns a line definition for the provided scales.
-     * @return {object} line
+     * @return {object} d3 path generator for line.
      */
     _createLine: function (xy, keys) {
-      // Monotone line goes through all datapoints. Other options are 'basis'
-      // which looks nice but can give inaccurate results, or 'cardinal' which
-      // results in a line with a bigger domain/amplitute than the data.
-      return d3.svg.line().interpolate('monotone')
-        .y(function (d) {
-          return xy.y.scale(d[keys.y]);
-        })
-        .x(function (d) {
-          return xy.x.scale(d[keys.x]);
-        })
+      return createPathGenerator(d3.svg.line)
+        .y(function (d) { return xy.y.scale(d[keys.y]); })
+        .x(function (d) { return xy.x.scale(d[keys.x]); })
         // interrupt the line when no data
         .defined(function (d) { return !isNaN(parseFloat(d[keys.y])); });
+    },
+
+
+    /**
+     * @function
+     * @memberOf angular.module('lizard-nxt').NxtD3
+     *s
+     * @param {object} xy object containing y.scales and x.scale.
+     * @param {object} keys object containing y.key and x.key.
+     * @description returns an area definition for the provided scales.
+     * @return {object} d3 path generator for area.
+     */
+    _createArea: function (xy, keys) {
+      return createPathGenerator(d3.svg.area)
+        .x(function(d) { return xy.x.scale(d[keys.x]); })
+        .y0(function(d) { return xy.y.scale(d[keys.y.y0]); })
+        .y1(function(d) { return xy.y.scale(d[keys.y.y1]); })
+        // interrupt the line when no data
+        .defined(function (d) {
+          var y0 = !isNaN(parseFloat(d[keys.y.y0]));
+          var y1 = !isNaN(parseFloat(d[keys.y.y1]));
+          return y0 && y1;
+        });
     },
 
     /**
@@ -479,6 +507,14 @@ angular.module('lizard-nxt')
       .attr('id', id)
       .attr("transform", "translate(0 ," + transform + ")");
   };
+
+  createPathGenerator = function (d3Generator) {
+    // Monotone line goes through all datapoints. Other options are 'basis'
+    // which looks nice but can give inaccurate results, or 'cardinal' which
+    // results in a line with a bigger domain/amplitute than the data.
+    return d3Generator().interpolate('monotone');
+  };
+
 
   return NxtD3;
 

--- a/app/lib/timeseries-service.js
+++ b/app/lib/timeseries-service.js
@@ -4,9 +4,10 @@
 angular.module('lizard-nxt')
   .service("TimeseriesService", ['CabinetService',
     function (CabinetService) {
-    var getTimeseries = function (id, timeState) {
+    var getTimeseries = function (id, timeState, minPoints) {
       return CabinetService.timeseries.get({
         object: id,
+        min_points: minPoints,
         start: parseInt(timeState.start, 10),
         end: parseInt(timeState.end, 10)
       });

--- a/app/styles/_colors.scss
+++ b/app/styles/_colors.scss
@@ -9,11 +9,10 @@ $darkgray3: #666666;
 $darkgray4: #777777;
 $darkgray: #333333;
 $greensea: #16a085; // Blue/greenish but darker
-$greenseaish: #138a72; // something someone made up?
+$turquoise: #1abc9c; // Blue/Greenish
 $midnightblue: #2c3e50; // Dark blue
 $pomegranate: #c0392b; // Darker red
 $silver: #bdc3c7; // medium-light grey
-$turquoise: #1abc9c; // Blue/Greenish
 $white1: #fbfbfb;
 $white: #ffffff;
 $bargrey: #95a5a6;

--- a/app/styles/_graph.scss
+++ b/app/styles/_graph.scss
@@ -24,15 +24,9 @@
 }
 
 .line {
-    fill: none;
-    stroke: darkcyan;
-    stroke-width: 2px;
-}
-
-.line2 {
-    fill: none;
-    stroke: crimson;
-    stroke-width: 2px;
+    fill: $greensea;
+    stroke: $greensea;
+    stroke-width: 3px;
 }
 
 .title {

--- a/test/spec/nxt-d3-tests.js
+++ b/test/spec/nxt-d3-tests.js
@@ -106,5 +106,16 @@ describe('Testing NxtD3', function () {
     }
   );
 
+  it('should return a path generator with monotone interpolator', function () {
+    var keys = {x: 0, y: 1};
+    var xy = {
+      'x': { scale: function () {} },
+      'y': { scale: function () {} }
+    };
+
+    var pathGen = nxtD3._createLine(xy, keys);
+    expect(pathGen.interpolate()).toBe('monotone');
+  });
+
 });
 

--- a/test/spec/nxt-d3-tests.js
+++ b/test/spec/nxt-d3-tests.js
@@ -67,6 +67,32 @@ describe('Testing NxtD3', function () {
     expect(maxMin.min).toEqual(1);
   });
 
+  it('should return correct max min for complex keys', function () {
+    var data = [
+      {
+        max: 1,
+        min: -3,
+        timestamp: 0
+      },
+      {
+        max: 2,
+        min: 0,
+        timestamp: 1
+      },
+      {
+        max: 4,
+        min: -2,
+        timestamp: 3
+      }
+    ],
+      key = {y0: 'min', y1: 'max'},
+      maxMin = nxtD3._maxMin(data, key);
+
+    expect(maxMin.max).toEqual(4);
+    expect(maxMin.min).toEqual(-3);
+  });
+
+
   it('should set new dimensions when resized', function () {
     newWidth = 40;
     nxtD3.resize({width: newWidth});


### PR DESCRIPTION
Adapt getData to use min_points for timeseries

Adapt getData calls for time-ctx and point

Adapt graph markup to include keys to the aggregated data

Adapt graphs to draw area lines when the keys have y1 and y2

Move some styling to css.

