### PR TITLE
fix https://github.com/nens/lizard-nxt/issues/880 regression from htt…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Unreleased (1.5.2) (XXXX-XX-XX)
 
 - Fix appending options of other layers to raster-aggregate requests.
 
+- Fix temporal wms layers not respecting temporal state changes.
+
 
 Release 1.5.3 (2015-5-27)
 ---------------------

--- a/app/components/map/services/map-service.js
+++ b/app/components/map/services/map-service.js
@@ -196,9 +196,10 @@ angular.module('map')
         if (lg.isActive() && lg.mapLayers.length > 0) {
           if (lg.temporal) {
             // copy timeState to layers so when added they will respect the
-            // current timestate.
+            // current timestate and can make independent descisions about when
+            // to sync to new timestate.
             angular.forEach(lg.mapLayers, function (layer) {
-              layer.timeState = State.temporal;
+              layer.timeState = angular.copy(State.temporal);
             });
           }
           addLayersRecursively(service._map, lg.mapLayers, 0);


### PR DESCRIPTION
…ps://github.com/nens/lizard-client/commit/eef810b75da6a89939ad6fc55cd4724120090624 . non tiled wms layer is supposed to keep track of its own timestate and make independent descisions about whether or not to take actions when syncTime is called