### PR TITLE
Request retina tiles.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog of lizard-nxt client
 Unreleased (1.5.9) (XXXX-XX-XX)
 -------------------------------
 
+- Fix bug no retina when https or v4 mapbox tile source.
+
 - Fix bug timeseries name and axis labels incorrect fields.
 
 

--- a/app/components/map/services/map-service.js
+++ b/app/components/map/services/map-service.js
@@ -458,8 +458,9 @@ angular.module('map')
 
         var layerUrl = nonLeafLayer.url + '/{slug}/{z}/{x}/{y}{retina}.{ext}';
 
-        // Mapbox layers support retina tiles, our own do not yet.
-        var retinaSupport = nonLeafLayer.url === 'http://{s}.tiles.mapbox.com/v3';
+        // Mapbox layers support retina tiles, our own do not yet. Check whether
+        // tiles are from mapbox source.
+        var retinaSupport = /mapbox.tiles/g.test(nonLeafLayer.url);
 
         var layer = LeafletService.tileLayer(
           layerUrl, {


### PR DESCRIPTION
We have a semi hacky check to decide to request retina tiles or not. It did not work when the tile url was https or referring to v4 mapbox  service... Now it does.