### PR TITLE
DONE: Ernst add regions rebased

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog of lizard-nxt client
 Unreleased (2.0.0) (XXXX-XX-XX)
 ---------------------
 
+- Add region aggregation as a fourth aggregation tool. Draw regions and get
+  raster aggregations when clicked.
+
 - Add angular-gettext for translations.
 
 - Add grunt tasks to extract and compile translations.

--- a/app/components/data-menu/data-menu.html
+++ b/app/components/data-menu/data-menu.html
@@ -57,7 +57,7 @@
                class="button-list-link"
                title="<% 'Point selection' | translate %>"
                ng-class="{'active': menu.box.type === 'point'}">
-               <i class="fa fa-dot-circle-o"></i>
+               <i class="fa fa-map-marker"></i>
             </a>
           </div>
 
@@ -68,6 +68,16 @@
                title="<% 'Line selection' | translate %>"
                ng-class="{'active': menu.box.type === 'line'}">
                <i class="fa fa-expand"></i>
+            </a>
+          </div>
+
+          <div class="button-list-item"
+               style="cursor: pointer">
+            <a ng-click="menu.box.type = 'region'"
+               class="button-list-link"
+               title="<% 'Region selection' | translate %>"
+               ng-class="{'active': menu.box.type === 'region'}">
+               <i class="fa fa-square"></i>
             </a>
           </div>
 

--- a/app/components/map/map-directives.js
+++ b/app/components/map/map-directives.js
@@ -18,7 +18,13 @@ angular.module('map')
   'DataService',
   'UtilService',
   'State',
-  function ($controller, MapService, DataService, UtilService, State) {
+  function (
+    $controller,
+    MapService,
+    DataService,
+    UtilService,
+    State
+  ) {
 
     var link = function (scope, element, attrs) {
 
@@ -94,7 +100,8 @@ angular.module('map')
           onMoveStart: _moveStarted,
           onMoveEnd: _moveEnded,
           onMouseMove: _mouseMove
-        });
+        }
+      );
 
       /**
        * Watch state spatial view and update the whole shebang.
@@ -160,6 +167,9 @@ angular.module('map')
         case "line":
           selector = "#map * {cursor: crosshair;}";
           break;
+        case "region":
+          selector = "";
+          break;
         case "area":
           selector = "#map * {cursor: -webkit-grab; cursor: -moz-grab; cursor: grab; cursor: hand;}";
           break;
@@ -167,6 +177,7 @@ angular.module('map')
           return;
         }
         UtilService.addNewStyle(selector);
+
       });
 
       init();

--- a/app/components/map/services/region-layer-service.js
+++ b/app/components/map/services/region-layer-service.js
@@ -22,6 +22,26 @@ angular.module('map')
     // ILayer of last region that recieved click.
     var previousActiveLayer;
 
+    var deafaultRegionStyle = {
+      weight: 2,
+      opacity: 0.6,
+      color: '#7f8c8d', // asbestos
+      fillOpacity: 0
+    };
+
+    var mouseOverStyle = {
+      fillColor: '#e74c3c', // alizarin
+      fillOpacity: 0.1
+    };
+
+    var activeRegionStyle = {
+      weight: 4,
+      fillColor: '#e74c3c', // alizarin
+      color: '#c0392b', // pomegranate
+      dashArray: '6',
+      fillOpacity: 0.1
+    };
+
     /**
      * Draws regions as a L.geoJson layer on the map. Sets click function. And
      * Fires click if ActiveRegionString is not falsy.
@@ -34,22 +54,14 @@ angular.module('map')
       regionsLayer = LeafletService.geoJson(regions, {
         // Style function must be included in order to overwrite style on click.
         style: function (feature) {
-          return {
-            weight: 2,
-            opacity: 0.6,
-            color: '#7f8c8d',
-            fillOpacity: 0
-          };
+          return deafaultRegionStyle;
         },
         onEachFeature: function (d, layer) {
           layer.on({
             mouseover: function (e) {
               var layer = e.target;
 
-              layer.setStyle({
-                  fillColor: '#e74c3c',
-                  fillOpacity: 0.1
-              });
+              layer.setStyle(mouseOverStyle);
 
             },
             mouseout: function (e) {
@@ -64,13 +76,7 @@ angular.module('map')
               }
 
               var newActiveLayer = e.target;
-              newActiveLayer.setStyle({
-                  weight: 4,
-                  fillColor: '#e74c3c',
-                  color: '#c0392b',
-                  dashArray: '6',
-                  fillOpacity: 0.1
-              });
+              newActiveLayer.setStyle(activeRegionStyle);
 
               clickCb(this);
 
@@ -104,9 +110,16 @@ angular.module('map')
         if (layer) {
           layer.fire('click');
         }
+        else {
+          activeRegionString = null;
+        }
       } else {
         activeRegionString = region;
       }
+    };
+
+    var getActiveRegion = function () {
+      return activeRegionString;
     };
 
     /**
@@ -130,7 +143,8 @@ angular.module('map')
     return {
       add: addRegions,
       remove: removeRegions,
-      setActiveRegion: setActiveRegion
+      setActiveRegion: setActiveRegion,
+      getActiveRegion: getActiveRegion
     };
 
   }]

--- a/app/components/map/services/region-layer-service.js
+++ b/app/components/map/services/region-layer-service.js
@@ -16,10 +16,10 @@ angular.module('map')
     // Leaflet geojson layer.
     var regionsLayer;
 
-    // ILayer of last region that recieved click.
+    // String of feature.properties.name that should be active.
     var activeRegionString;
 
-    // ILayer of 2nd to last region that recieved click.
+    // ILayer of last region that recieved click.
     var previousActiveLayer;
 
     /**

--- a/app/components/map/services/region-layer-service.js
+++ b/app/components/map/services/region-layer-service.js
@@ -63,11 +63,6 @@ angular.module('map')
                 regionsLayer.resetStyle(previousActiveLayer);
               }
 
-
-              if (!L.Browser.ie && !L.Browser.opera) {
-                layer.bringToFront();
-              }
-
               var newActiveLayer = e.target;
               newActiveLayer.setStyle({
                   weight: 4,

--- a/app/components/map/services/region-layer-service.js
+++ b/app/components/map/services/region-layer-service.js
@@ -1,0 +1,109 @@
+'use strict';
+
+/**
+ * @ngdoc service
+ * @name map.NxtRegionsLayer
+ * @description
+ * Adds a leaflet geojson layer to draw regions.
+ */
+angular.module('map')
+.factory('NxtRegionsLayer', [
+  'MapService',
+  'CabinetService',
+  'LeafletService',
+  function (MapService, CabinetService, LeafletService) {
+
+    // Leaflet geojson layer.
+    var regionsLayer;
+
+    // ILayer of last region that recieved click.
+    var activeRegionString;
+
+    // ILayer of 2nd to last region that recieved click.
+    var previousActiveLayer;
+
+    /**
+     * Draws regions as a L.geoJson layer on the map. Sets click function. And
+     * Fires click if ActiveRegionString is not falsy.
+     *
+     * @param  {geojson}  regions
+     * @param  {funciton} clickCb callback fires when layer is clicked.
+     */
+    var addRegions = function (regions, clickCb) {
+      MapService.removeLeafletLayer(regionsLayer);
+      regionsLayer = LeafletService.geoJson(regions, {
+        // Style function must be included in order to overwrite style on click.
+        style: function (feature) { return {}; },
+        onEachFeature: function (d, layer) {
+          layer.on('click', function (e) {
+            if (previousActiveLayer) {
+              regionsLayer.resetStyle(previousActiveLayer);
+            }
+            var newActiveLayer = e.target;
+            newActiveLayer.setStyle({
+                weight: 5,
+                color: 'red',
+                dashArray: '',
+                fillOpacity: 0.7
+            });
+            clickCb(this);
+
+            activeRegionString = newActiveLayer.feature.properties.name;
+            previousActiveLayer = newActiveLayer;
+          });
+        }
+      });
+      MapService.addLeafletLayer(regionsLayer);
+      if (activeRegionString) { setActiveRegion(activeRegionString); }
+    };
+
+    /**
+     * Removes the regions from the map and sets activeRegioString to null.
+     */
+    var removeRegions = function () {
+      activeRegionString = null;
+      MapService.removeLeafletLayer(regionsLayer);
+    };
+
+    /**
+     * Sets the activeRegion, by firing a click when regionsLayer exists, or
+     * sets activeRegionString that triggers a call of this function onload.
+     *
+     * @param {string} region properties.name of region.
+     */
+    var setActiveRegion = function (region) {
+      if (regionsLayer) {
+        var layer = _getRegion(regionsLayer, region);
+        if (layer) {
+          layer.fire('click');
+        }
+      } else {
+        activeRegionString = region;
+      }
+    };
+
+    /**
+     * Gets region layer with properties.name === regionName of the currently
+     * drawn regions.
+     *
+     * @param  {L.GeoJson} lGeo        Leaflet L.GeoJson instance.
+     * @param  {string} regionName     Properties.name of region
+     * @return {L.ILayer || undefined} Region layer.
+     */
+    var _getRegion = function (lGeo, regionName) {
+      var region;
+      lGeo.eachLayer(function (layer) {
+        if (layer.feature.properties.name === regionName) {
+          region = layer;
+        }
+      });
+    };
+
+    return {
+      add: addRegions,
+      remove: removeRegions,
+      setActiveRegion: setActiveRegion
+    };
+
+  }]
+);

--- a/app/components/map/services/region-layer-service.js
+++ b/app/components/map/services/region-layer-service.js
@@ -33,23 +33,55 @@ angular.module('map')
       MapService.removeLeafletLayer(regionsLayer);
       regionsLayer = LeafletService.geoJson(regions, {
         // Style function must be included in order to overwrite style on click.
-        style: function (feature) { return {}; },
+        style: function (feature) {
+          return {
+            weight: 2,
+            opacity: 0.6,
+            color: '#7f8c8d',
+            fillOpacity: 0
+          };
+        },
         onEachFeature: function (d, layer) {
-          layer.on('click', function (e) {
-            if (previousActiveLayer) {
-              regionsLayer.resetStyle(previousActiveLayer);
-            }
-            var newActiveLayer = e.target;
-            newActiveLayer.setStyle({
-                weight: 5,
-                color: 'red',
-                dashArray: '',
-                fillOpacity: 0.7
-            });
-            clickCb(this);
+          layer.on({
+            mouseover: function (e) {
+              var layer = e.target;
 
-            activeRegionString = newActiveLayer.feature.properties.name;
-            previousActiveLayer = newActiveLayer;
+              layer.setStyle({
+                  fillColor: '#e74c3c',
+                  fillOpacity: 0.1
+              });
+
+            },
+            mouseout: function (e) {
+              if (e.target.feature.properties.name !== activeRegionString) {
+                regionsLayer.resetStyle(e.target);
+              }
+            },
+            click: function (e) {
+
+              if (previousActiveLayer) {
+                regionsLayer.resetStyle(previousActiveLayer);
+              }
+
+
+              if (!L.Browser.ie && !L.Browser.opera) {
+                layer.bringToFront();
+              }
+
+              var newActiveLayer = e.target;
+              newActiveLayer.setStyle({
+                  weight: 4,
+                  fillColor: '#e74c3c',
+                  color: '#c0392b',
+                  dashArray: '6',
+                  fillOpacity: 0.1
+              });
+
+              clickCb(this);
+
+              activeRegionString = newActiveLayer.feature.properties.name;
+              previousActiveLayer = newActiveLayer;
+            }
           });
         }
       });

--- a/app/components/map/services/region-layer-service.js
+++ b/app/components/map/services/region-layer-service.js
@@ -97,6 +97,7 @@ angular.module('map')
           region = layer;
         }
       });
+      return region;
     };
 
     return {

--- a/app/components/omnibox/controllers/point-controller.js
+++ b/app/components/omnibox/controllers/point-controller.js
@@ -192,6 +192,7 @@ angular.module('omnibox')
     $scope.$on('$destroy', function () {
       DataService.reject('omnibox');
       $scope.box.content = {};
+      State.spatial.points = [];
       ClickFeedbackService.emptyClickLayer(MapService);
     });
   }

--- a/app/components/omnibox/controllers/region-controller.js
+++ b/app/components/omnibox/controllers/region-controller.js
@@ -1,0 +1,98 @@
+/**
+ * @ngdoc
+ * @class regionCtrl
+ * @memberOf omnibox
+ * @name RegionCtrl
+ * @description
+ *
+ * Reguests data for the active region When box.type is region. Regions are
+ * spatial areas such as administrative boundaries or watersheds.
+ *
+ * Contains data of all active raster layers with an aggregation_type
+ *
+ */
+angular.module('omnibox')
+.controller('RegionCtrl', [
+
+  '$scope',
+  'CabinetService',
+  'DataService',
+  'NxtRegionsLayer',
+  'State',
+
+  function (
+
+    $scope,
+    CabinetService,
+    DataService,
+    NxtRegionsLayer,
+    State
+
+  ) {
+
+
+    /**
+     * Callback for clicks on regions. Calls fillbox of omnibox scope. Sets the
+     * clicked region on the State and the name of the region on the scope.
+     *
+     * @param  {leaflet ILayer} layer that recieved the click.
+     */
+    var clickCb = function (layer) {
+      $scope.fillBox({
+        geom: State.spatial.region.geometry,
+        start: State.temporal.start,
+        end: State.temporal.end,
+        aggWindow: State.temporal.aggWindow,
+        type: 'Raster' // Regions only get data for rasters.
+      });
+
+      State.spatial.region = layer.feature;
+      $scope.activeName = layer.feature.properties.name;
+    };
+
+    /**
+     * Makes call to api for regions of the given bounds and zoom and calls
+     * NxtRegionsLayer.add function with  response.
+     */
+    var createRegions = function () {
+      CabinetService.regions.get({
+        z: State.spatial.view.zoom,
+        in_bbox: State.spatial.bounds.getWest()
+          + ','
+          + State.spatial.bounds.getNorth()
+          + ','
+          + State.spatial.bounds.getEast()
+          + ','
+          + State.spatial.bounds.getSouth()
+      })
+      .then(function (regions) {
+        NxtRegionsLayer.add(regions.results, clickCb);
+      });
+    };
+
+    // init
+    createRegions();
+
+
+    /**
+     * Updates area when user moves map.
+     */
+    $scope.$watch(State.toString('spatial.bounds'), function (n, o) {
+      if (n === o) { return true; }
+      createRegions();
+    });
+
+    $scope.$watch(State.toString('spatial.region'), function (n, o) {
+      if (n === o) { return true; }
+      createRegions();
+    });
+
+    // Clean up stuff when controller is destroyed
+    $scope.$on('$destroy', function () {
+      DataService.reject('omnibox');
+      $scope.box.content = {};
+      State.spatial.region = {};
+      NxtRegionsLayer.remove();
+    });
+
+  }]);

--- a/app/components/omnibox/controllers/region-controller.js
+++ b/app/components/omnibox/controllers/region-controller.js
@@ -1,9 +1,20 @@
 /**
  * @ngdoc
+<<<<<<< HEAD
  * @class regionCtrl
  * @memberOf omnibox
  * @name RegionCtrl
  * @description
+=======
+ * @class areaCtrl
+ * @memberOf app
+ * @name RegionCtrl
+ * @description
+ *
+ * Reguests data for the active region When box.type is region. Region are
+ * spatial areas such as administrative boundaries or watersheds.
+ *
+>>>>>>> 2c3b4e0... make url and box.content and box.type consistentently work
  *
  * Reguests data for the active region When box.type is region. Regions are
  * spatial areas such as administrative boundaries or watersheds.
@@ -16,16 +27,16 @@ angular.module('omnibox')
 
   '$scope',
   'CabinetService',
-  'DataService',
   'NxtRegionsLayer',
+  'DataService',
   'State',
 
   function (
 
     $scope,
     CabinetService,
-    DataService,
     NxtRegionsLayer,
+    DataService,
     State
 
   ) {
@@ -39,11 +50,10 @@ angular.module('omnibox')
      */
     var clickCb = function (layer) {
       $scope.fillBox({
-        geom: State.spatial.region.geometry,
+        geom: layer.feature.geometry,
         start: State.temporal.start,
         end: State.temporal.end,
-        aggWindow: State.temporal.aggWindow,
-        type: 'Raster' // Regions only get data for rasters.
+        aggWindow: State.temporal.aggWindow
       });
 
       State.spatial.region = layer.feature;
@@ -73,19 +83,22 @@ angular.module('omnibox')
     // init
     createRegions();
 
-
     /**
-     * Updates area when user moves map.
+     * Updates regions when user moves map.
      */
     $scope.$watch(State.toString('spatial.bounds'), function (n, o) {
       if (n === o) { return true; }
       createRegions();
     });
 
-    $scope.$watch(State.toString('spatial.region'), function (n, o) {
+    /**
+     * Updates region data when users changes layers.
+     */
+    $scope.$watch(State.toString('layerGroups.active'), function (n, o) {
       if (n === o) { return true; }
       createRegions();
     });
+
 
     // Clean up stuff when controller is destroyed
     $scope.$on('$destroy', function () {

--- a/app/components/omnibox/templates/region.html
+++ b/app/components/omnibox/templates/region.html
@@ -1,0 +1,61 @@
+<div ng-controller="RegionCtrl">
+
+	<div ng-if="activeName" class="card active" id="card-<% slug %>">
+    <div class="card-content">
+			<% activeName %>
+		</div>
+	</div>
+
+  <div ng-repeat="(slug, lg) in box.content"
+       ng-if="slug !== 'rain' && slug !== 'waterchain'"
+       class="card active" id="card-<% slug %>">
+
+    <div
+      ng-repeat="(lslug, l) in lg.layers"
+      ng-if="!!l && l.data"
+      ng-switch="l.aggType"
+      class="card-content"
+      id="card-content-<% l.name %>">
+
+      <graph
+        ng-switch-when="curve"
+        line xlabel="'[%]'"
+        ylabel="l.unit"
+        data="l.data"
+        keys="{x: 0, y: 1}">
+      </graph>
+
+      <graph
+        ng-switch-when="histogram"
+        bar-chart
+        quantity="'linear'"
+        ylabel="'[%]'"
+        xlabel="l.unit"
+        data="l.data"
+        keys="{x: 0, y: 1}">
+      </graph>
+
+      <graph
+        ng-switch-when="counts"
+        horizontal-stack
+        data="l.data"
+        keys="{x: 'data', y: 'label'}"
+        xlabel="'[%]'"
+        dimensions="{height: 80, padding: {left: 0, right: 0, top: 5, bottom: 50}}">
+      </graph>
+
+      <div ng-switch-default ng-switch="l.format">
+
+        <graph
+          ng-switch-when="Store"
+          line
+          data="l.data">
+        </graph>
+
+      </div>
+
+    </div>
+
+  </div>
+
+</div>

--- a/app/components/state/state-service.js
+++ b/app/components/state/state-service.js
@@ -69,7 +69,7 @@ angular.module('global-state')
     state.box = {};
 
     var _type = 'point'; // Default box type
-    var TYPE_VALUES = ["point", "line", "area"];
+    var TYPE_VALUES = ["point", "line", "region", "area"];
     Object.defineProperty(state.box, 'type', {
       get: function () { return _type; },
       set: function (type) {
@@ -90,6 +90,8 @@ angular.module('global-state')
     state.spatial = {
       here: {},
       points: [], // History of here for drawing and creating line and polygons
+      region: {},// geojson feature describing region, with name and type in
+              // properties
       bounds: {},
       view: {}, // { lat: <int>, lng:<int>, zoom:<int> }
       userHere: {}, // Geographical location of the users mouse only set by

--- a/app/components/url/url-controller.js
+++ b/app/components/url/url-controller.js
@@ -249,6 +249,16 @@ angular.module('lizard-nxt')
     });
 
     /**
+     * Set region when State.spatial.region changed and box.type is region.
+     */
+    $scope.$watch(State.toString('spatial.region'), function (n, o) {
+      if (n === o || State.box.type !== 'region') { return true; }
+      LocationGetterSetter.setUrlValue(
+        state.geom.part, state.geom.index, State.spatial.region.properties.name
+      );
+    });
+
+    /**
      * Listener to update map view when user changes url
      *
      * $locationChangeSucces is broadcasted by angular

--- a/app/components/url/url-controller.js
+++ b/app/components/url/url-controller.js
@@ -21,6 +21,7 @@ angular.module('lizard-nxt')
   'defaultLocale',
   'DataService',
   'MapService',
+  'NxtRegionsLayer',
   'State',
   '$rootScope',
   'LeafletService',
@@ -34,6 +35,7 @@ angular.module('lizard-nxt')
     defaultLocale,
     DataService,
     MapService,
+    NxtRegionsLayer,
     State,
     $rootScope,
     LeafletService,
@@ -205,12 +207,13 @@ angular.module('lizard-nxt')
         state.boxType.part, state.boxType.index, State.box.type
       );
 
-      if (old === 'point' || old === 'line') {
+      if (old === 'point' || old === 'line' || old === 'region') {
         // Remove geometry from url
         state.boxType.update = false;
         LocationGetterSetter.setUrlValue(
           state.geom.part, state.geom.index, undefined);
       }
+
     });
 
     /*
@@ -230,10 +233,12 @@ angular.module('lizard-nxt')
     $scope.$watch(State.toString('spatial.here'), function (n, o) {
       if (n === o || State.box.type !== 'point') { return true; }
       state.geom.update = false;
-      UrlState.setgeomUrl(state,
-                          State.box.type,
-                          State.spatial.here,
-                          State.spatial.points);
+      UrlState.setgeomUrl(
+        state,
+        State.box.type,
+        State.spatial.here,
+        State.spatial.points
+      );
     });
 
     /**
@@ -308,7 +313,11 @@ angular.module('lizard-nxt')
       }
 
       if (geom) {
-        State.spatial = UrlState.parseGeom(State.box.type, geom, State.spatial);
+        if (/\d/.test(geom)) {
+          State.spatial = UrlState.parseGeom(State.box.type, geom, State.spatial);
+        } else {
+          NxtRegionsLayer.setActiveRegion(geom);
+        }
       }
 
       enablelayerGroups(layerGroupsFromURL);

--- a/app/components/url/url-controller.js
+++ b/app/components/url/url-controller.js
@@ -258,9 +258,15 @@ angular.module('lizard-nxt')
      */
     $scope.$watch(State.toString('spatial.region'), function (n, o) {
       if (n === o || State.box.type !== 'region') { return true; }
-      LocationGetterSetter.setUrlValue(
-        state.geom.part, state.geom.index, State.spatial.region.properties.name
-      );
+      if (State.spatial.region.properties) {
+        LocationGetterSetter.setUrlValue(
+          state.geom.part, state.geom.index, State.spatial.region.properties.name
+        );
+      } else {
+        LocationGetterSetter.setUrlValue(
+          state.geom.part, state.geom.index, ''
+        );
+      }
     });
 
     /**

--- a/app/index.html
+++ b/app/index.html
@@ -140,6 +140,7 @@
     <script src="/components/url/url-service.js"></script>
 
     <script src="/components/map/map.js"></script>
+    <script src="/components/map/services/region-layer-service.js"></script>
     <script src="/components/map/services/non-tiled-wms-layer-service.js"></script>
     <script src="/components/map/services/map-layer-service.js"></script>
     <script src="/components/map/services/map-service.js"></script>
@@ -154,6 +155,7 @@
     <script src="/components/omnibox/controllers/point-controller.js"></script>
     <script src="/components/omnibox/controllers/rain-controller.js"></script>
     <script src="/components/omnibox/controllers/line-controller.js"></script>
+    <script src="/components/omnibox/controllers/region-controller.js"></script>
     <script src="/components/omnibox/controllers/area-controller.js"></script>
     <script src="/components/omnibox/directives/template-directives.js"></script>
     <script src="/components/omnibox/directives/search-directive.js"></script>

--- a/app/lib/cabinet-service.js
+++ b/app/lib/cabinet-service.js
@@ -18,6 +18,7 @@ angular.module('lizard-nxt')
 
   timeseriesResource = Restangular.one('api/v1/timeseries/');
   events = Restangular.one('api/v1/events/');
+  var regions = Restangular.one('api/v1/regions/');
 
   geocodeResource = Restangular
     // Use a different base url, go directly to our friends at google.
@@ -92,5 +93,6 @@ angular.module('lizard-nxt')
     geocode: geocodeResource,
     raster: rasterResource,
     timeseries: timeseriesResource,
+    regions: regions
   };
 }]);

--- a/app/lib/utfgrid-service.js
+++ b/app/lib/utfgrid-service.js
@@ -71,7 +71,10 @@ angular.module('lizard-nxt')
           response,
           cacheKey = buildCacheKey(nonLeafLayer, options);
 
-      if (options.geom === undefined || geomType === "LINE") {
+      if (
+        options.geom === undefined
+        || geomType === "LINE"
+        || geomType === "REGION") {
         deferred.reject();
         return deferred.promise;
       }

--- a/test/spec/regions-layer-service-test.js
+++ b/test/spec/regions-layer-service-test.js
@@ -1,0 +1,108 @@
+'use strict';
+
+describe('Testing NxtRegionsLayer', function () {
+  var NxtRegionsLayer,
+      MapService;
+
+  beforeEach(module('map'));
+  beforeEach(module('lizard-nxt'));
+
+  beforeEach(inject(function ($injector) {
+    NxtRegionsLayer = $injector.get('NxtRegionsLayer');
+
+    MapService = $injector.get('MapService');
+    var el = angular.element('<div></div>');
+    MapService.initializeMap(el[0], {});
+  }));
+
+  var regions = {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "id": "",
+        "type": "Feature",
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                6.73223393753252,
+                52.892182439611666
+              ],
+              [
+                6.73633707130147,
+                52.87869128709281
+              ],
+              [
+                6.714563920865843,
+                52.86815881513394
+              ]
+            ]
+          ]
+        },
+        "properties": {
+          "name": "Aa en Hunze",
+          "type": "MUNICIPALITY"
+        }
+      },
+      {
+        "id": "",
+        "type": "Feature",
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                5.081756603739015,
+                51.722289503493954
+              ],
+              [
+                5.071325236745616,
+                51.717040767307246
+              ]
+            ]
+          ]
+        },
+        "properties": {
+          "name": "Aalburg",
+          "type": "MUNICIPALITY"
+        }
+      }
+    ]
+  };
+
+  it('should fire a click on specific region', function () {
+
+    var regionString = 'Aalburg';
+    NxtRegionsLayer.setActiveRegion(regionString);
+
+    var clickedRegion = {};
+
+    var cb = function (layer) {
+      clickedRegion = layer;
+    };
+
+    NxtRegionsLayer.add(regions, cb);
+
+    expect(clickedRegion.feature.properties.name).toBe(regionString);
+  });
+
+  it('should not fire a click after re-adding', function () {
+
+    var regionString = 'Aalburg';
+    NxtRegionsLayer.setActiveRegion(regionString);
+
+    var clickedRegion;
+
+    var cb = function (layer) {
+      clickedRegion = layer;
+    };
+
+    NxtRegionsLayer.add(regions, function () {});
+    NxtRegionsLayer.remove();
+    NxtRegionsLayer.add(regions, cb);
+
+    expect(clickedRegion).not.toBeDefined();
+  });
+
+});

--- a/test/spec/state-service-tests.js
+++ b/test/spec/state-service-tests.js
@@ -40,6 +40,11 @@ describe('Testing State service', function () {
     );
   });
 
+  it('should have a box type that can have the value region', function () {
+    State.box.type = 'region';
+    expect(State.box.type).toBe('region');
+  });
+
 });
 
 describe('Testing State toString', function () {


### PR DESCRIPTION
Part of the bottom part of https://github.com/nens/lizard-nxt/issues/925
Comes with https://github.com/nens/lizard-nxt/pull/930

Add regions aggregation as a fourth aggregation mode. 
Created a new service to draw regions as geojson.
Add endpoint to cabinetservice.
Add regions as a box type to State and utilservice.
Add region name to url with two way binding on the name of the region.
Add region omnibox controller to get regions and get raster agggregations for clicked regions.