### PR TITLE
Arjen polygon agg updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ doc/
 po/template.pot
 # generate using grunt nggettext_compile
 app/translations.js
+
+# vi
+*.swp

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Unreleased (2.0.0) (XXXX-XX-XX)
 
 - Region name **strong** in card title.
 
+- Display area of region in card title for region aggregates.
+
 - Fix baselanguage not an option from url.
 
 - Change region icon to lemon.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog of lizard-nxt client
 Unreleased (2.0.0) (XXXX-XX-XX)
 ---------------------
 
+- Get raster aggregates for polygons by geometry id instead of WKT polygon.
+
+- Region name **strong** in card title.
+
 - Fix baselanguage not an option from url.
 
 - Change region icon to lemon.

--- a/app/components/omnibox/controllers/region-controller.js
+++ b/app/components/omnibox/controllers/region-controller.js
@@ -48,6 +48,9 @@ angular.module('omnibox')
      * @param  {leaflet ILayer} layer that recieved the click.
      */
     var clickCb = function (layer) {
+      // NOTE: is this the proper place to convert m2 to ha?
+      var HECTARE_IN_M2 = 10000;
+
       $scope.fillBox({
         geom_id: layer.feature.id,
         // apparantly this cannnot be left out because of some type check.
@@ -59,9 +62,8 @@ angular.module('omnibox')
 
       State.spatial.region = layer.feature;
       $scope.activeName = layer.feature.properties.name;
-      //$scope.regionArea = layer.features.geometry;
-      $scope.regionArea = 128;
-      console.log(layer.feature.geometry);
+      $scope.regionArea = Math.round(layer.feature.properties.area /
+                                     HECTARE_IN_M2);
     };
 
     /**

--- a/app/components/omnibox/controllers/region-controller.js
+++ b/app/components/omnibox/controllers/region-controller.js
@@ -48,7 +48,6 @@ angular.module('omnibox')
      * @param  {leaflet ILayer} layer that recieved the click.
      */
     var clickCb = function (layer) {
-      // NOTE: is this the proper place to convert m2 to ha?
       var HECTARE_IN_M2 = 10000;
 
       $scope.fillBox({

--- a/app/components/omnibox/controllers/region-controller.js
+++ b/app/components/omnibox/controllers/region-controller.js
@@ -49,6 +49,8 @@ angular.module('omnibox')
      */
     var clickCb = function (layer) {
       $scope.fillBox({
+        geom_id: layer.feature.id,
+        // apparantly this cannnot be left out because of some type check.
         geom: layer.feature.geometry,
         start: State.temporal.start,
         end: State.temporal.end,
@@ -57,6 +59,9 @@ angular.module('omnibox')
 
       State.spatial.region = layer.feature;
       $scope.activeName = layer.feature.properties.name;
+      //$scope.regionArea = layer.features.geometry;
+      $scope.regionArea = 128;
+      console.log(layer.feature.geometry);
     };
 
     /**

--- a/app/components/omnibox/templates/region.html
+++ b/app/components/omnibox/templates/region.html
@@ -2,7 +2,7 @@
 
 	<div ng-if="activeName" class="card active" id="card-<% slug %>">
     <div class="card-content">
-          <strong><% activeName %><strong>
+          <strong><% activeName %></strong> <% regionArea %> ha.
 		</div>
 	</div>
 

--- a/app/components/omnibox/templates/region.html
+++ b/app/components/omnibox/templates/region.html
@@ -2,7 +2,7 @@
 
 	<div ng-if="activeName" class="card active" id="card-<% slug %>">
     <div class="card-content">
-			<% activeName %>
+          <strong><% activeName %><strong>
 		</div>
 	</div>
 

--- a/app/lib/raster-service.js
+++ b/app/lib/raster-service.js
@@ -19,7 +19,6 @@ angular.module('lizard-nxt')
 
     var srs = 'EPSG:4326',
         agg = options.agg || '',
-        wkt = UtilService.geomToWkt(options.geom),
         startString,
         endString,
         aggWindow;
@@ -54,7 +53,6 @@ angular.module('lizard-nxt')
 
     var requestOptions = {
       raster_names: layer.slug,
-      geom: wkt,
       srs: srs,
       start: startString,
       stop: endString,
@@ -62,6 +60,13 @@ angular.module('lizard-nxt')
       styles: options.styles,
       window: aggWindow
     };
+
+    if (options.geom_id) {
+      requestOptions.geom_id = options.geom_id; 
+    } else {
+      requestOptions.geom = UtilService.geomToWkt(options.geom); 
+    }
+
     if (options.truncate === true) {
       requestOptions.truncate = options.truncate;
     }

--- a/app/lib/util-service.js
+++ b/app/lib/util-service.js
@@ -439,6 +439,8 @@ angular.module('lizard-nxt')
    * @return {string} - "POINT" | "LINE" | "AREA" | throw new Error!
    *
    * TODO: get rid of this maniacal reverse engineering of our own code.
+   * NOTE: geojson features have a `type` property on their geometry.
+   * could be as easy as `feature.geometry.type`.
    */
   this.getGeomType = function (geomOpts) {
 

--- a/app/lib/util-service.js
+++ b/app/lib/util-service.js
@@ -439,7 +439,6 @@ angular.module('lizard-nxt')
    * @return {string} - "POINT" | "LINE" | "AREA" | throw new Error!
    *
    * TODO: get rid of this maniacal reverse engineering of our own code.
-   * NOTE: geojson features have a `type` property on their geometry.
    * could be as easy as `feature.geometry.type`.
    */
   this.getGeomType = function (geomOpts) {


### PR DESCRIPTION
Small fixes to improve region tool functioning.

* Request aggregate by geometry id instead of wkt polygon to prevent too long request urls

* Region name in title card **bold**

* Area in ha in region card after region name

We might want to select a unit for area depending on zoom level / locale fix that server side.

Comes with: https://github.com/nens/lizard-nxt/pull/986

Implements: https://github.com/nens/lizard-nxt/issues/925