### PR TITLE
Get feature info

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog of lizard-nxt client
 Unreleased (2.0.3) (XXXX-XX-XX)
 ---------------------
 
+- Only create a data layer for wms if get_feature_info is true.
+
 - Add username to sentry.
 
 - Send errors from all lizard portals to sentry projects.

--- a/app/components/data-menu/services/data-layer-group-service.js
+++ b/app/components/data-menu/services/data-layer-group-service.js
@@ -101,7 +101,7 @@ angular.module('data-menu')
 
           if (layer.format === 'UTFGrid'
             || layer.format === 'Vector'
-            || layer.format === 'WMS') {
+            || (layer.format === 'WMS' && layer.get_feature_info)) {
             var nxtLayer = new NxtDataLayer(layer, tempRes);
             this._dataLayers.push(nxtLayer);
             this.mapLayers.push(nxtLayer);
@@ -119,7 +119,8 @@ angular.module('data-menu')
               this.spatialBounds = layer.meta.spatial_bounds;
             }
           }
-          else if (layer.format === 'TMS') {
+          else if (layer.format === 'TMS'
+            || (layer.format === 'WMS' && !layer.get_feature_info)) {
             this.mapLayers.push(new NxtLayer(layer, tempRes));
           }
         }, this);


### PR DESCRIPTION
Only create a data layer for wms if get_feature_info is true other part of the fix for: https://github.com/nens/lizard-nxt/issues/1016

Comes with: https://github.com/nens/lizard-nxt/pull/1019