### PR TITLE
use current language of portal or url in searchresults

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Unreleased (2.1.0) (XXXX-XX-XX)
 
 - Handle new and old landuse labels in filters.
 
+- Use the current language of portal or url in search results.
+
 
 Release 2.0.9 (2015-9-11)
 ---------------------

--- a/app/components/omnibox/services/search-service.js
+++ b/app/components/omnibox/services/search-service.js
@@ -35,7 +35,7 @@ angular.module('omnibox')
       // on portal by adding: components: 'country:NL'.
       var prom = CabinetService.geocode.get({
         address: searchString,
-        language: 'nl', // Return results in Dutch
+        language: state.language, // Preferred language of search results.
         bounds: // Prefer results from the current viewport
           state.spatial.bounds.getSouth() + ',' +
           state.spatial.bounds.getWest() + '|' +

--- a/app/components/state/state-service.js
+++ b/app/components/state/state-service.js
@@ -48,6 +48,9 @@ angular.module('global-state')
       }
     });
 
+    // Default language.
+    state.language = 'nl';
+
     // State of data layer groups, stores slugs of all layergroups and the
     // active layergroups.
     state.layerGroups = {

--- a/app/components/url/url-controller.js
+++ b/app/components/url/url-controller.js
@@ -136,7 +136,7 @@ angular.module('lizard-nxt')
      * @param {str} lang language code according to ISO-639-1.
      */
     var setLanguage = function (lang) {
-      var defaultLang = 'nl';
+      var defaultLang = State.language;
 
       if (lang === undefined && defaultLocale) {
         lang = defaultLocale.slice(0,2); // language is the first 2 places of
@@ -152,6 +152,10 @@ angular.module('lizard-nxt')
       }
 
       gettextCatalog.setCurrentLanguage(lang);
+
+      // Store language in global state object. Among other, it is used for
+      // searchresults.
+      State.language = lang;
     };
 
     /**


### PR DESCRIPTION
Request from Evert for GGMN project:

- [x] Add language to state from url-controller (where the language is set from portal's language or url)
- [x] Include state.language in search request.
