### PR TITLE
Add cmd line host+port options for grunt serve

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,8 @@ Changelog of lizard-nxt client
 
 Unreleased (2.2.1) (XXXX-XX-XX)
 ---------------------
--
+
+- Add command line host + port options for grunt serve.
 
 
 Release 2.2.1 (2015-10-16)

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -90,9 +90,9 @@ module.exports = function (grunt) {
     // The actual grunt server settings
     connect: {
       options: {
-        port: 9000,
+        port: grunt.option('port') || 9000,
         // Change this to '0.0.0.0' to access the server from outside.
-        hostname: 'localhost',
+        hostname: grunt.option('hostname') ? grunt.option('hostname') + '' : 'localhost',
         livereload: 35729
       },
       livereload: {


### PR DESCRIPTION
One of the two methods of installing lizard-client is: *from within lizard-nxt using mr. developer* (see README.md). I chose this method, which is apparently not used that much, but I still want to run the client in my Vagrant box. I managed to run it by changing the hostname to 0.0.0.0 in the Gruntfile config, but since it's already a committed file I've added options for it using grunt.option. So the default ```grunt serve``` is still using localhost and 9000, but you can also do something like: ```grunt serve --hostname=0.0.0.0 --port=9000```.