### PR TITLE
Support for region aggregation other than AdminBounds

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,11 @@ Unreleased (2.2.1) (XXXX-XX-XX)
 - Fix empty select box for nested assets, use serial whem code is not available
   and use id when serial is not available either.
 
+- Send boundary_type to server in region selection to be able to not only select
+  admin bounds regions but "pumped drainage area", "fixed drainage level area"
+  and "polder" as well.
+
+
 Release 2.2.1 (2015-10-16)
 ---------------------
 

--- a/app/components/omnibox/controllers/region-controller.js
+++ b/app/components/omnibox/controllers/region-controller.js
@@ -67,6 +67,7 @@ angular.module('omnibox')
 
       $scope.fillBox({
         geom_id: feature.id,
+        boundary_type: feature.properties.type,
         // apparantly this cannnot be left out because of some type check.
         geom: feature.geometry,
         start: State.temporal.start,

--- a/app/lib/raster-service.js
+++ b/app/lib/raster-service.js
@@ -63,6 +63,7 @@ angular.module('lizard-nxt')
 
     if (options.geom_id) {
       requestOptions.geom_id = options.geom_id; 
+      requestOptions.boundary_type = options.boundary_type;
     } else {
       requestOptions.geom = UtilService.geomToWkt(options.geom); 
     }


### PR DESCRIPTION
Send boundary_type to server in region selection to be able to not only select admin bounds regions but "pumped drainage area", "fixed drainage level area" and "polder" as well.