### PR TITLE
Ernst animate rasters using smaller bounds

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog of lizard-nxt client
 Unreleased (2.2.5) (XXXX-XX-XX)
 ---------------------
 
+- Fix click on animation pause button not registered.
+
 - Animate only the intersection of map bounds and layer bounds, to have more
   resolution with less data.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog of lizard-nxt client
 Unreleased (2.2.5) (XXXX-XX-XX)
 ---------------------
 
+- Animate only the intersection of map bounds and layer bounds, to have more
+  resolution with less data.
+
 - Store bounds of layer on group and layer for zooming to lg and animating wms.
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,8 @@ Changelog of lizard-nxt client
 
 Unreleased (2.2.5) (XXXX-XX-XX)
 ---------------------
--
+
+- Store bounds of layer on group and layer for zooming to lg and animating wms.
 
 
 Release 2.2.6 (2015-11-13)

--- a/app/components/data-menu/services/layer-service.js
+++ b/app/components/data-menu/services/layer-service.js
@@ -50,9 +50,11 @@ angular.module('data-menu')
           value: temporalResolution,
           writable: true,
         });
+        // Bounds are set from the layer config in lizard-bs or set from the
+        // layergroup when data-layer-group-service initiates layergroups.
         Object.defineProperty(this, 'bounds', {
-          value: layer.bounds,
-          writable: false,
+          value: layer.meta && layer.meta.spatial_bounds,
+          writable: true,
         });
         Object.defineProperty(this, 'color', {
           value: layer.color,

--- a/app/components/map/services/map-service.js
+++ b/app/components/map/services/map-service.js
@@ -274,6 +274,7 @@ angular.module('map')
             layer._leafletLayer = initializers[layer.format](layer);
             angular.extend(layer, NxtMapLayer);
           } else if (layer.format === 'WMS') {
+            if (!layer.bounds) { layer.bounds = lg.spatialBounds; }
             layer = NxtNonTiledWMSLayer.create(layer);
           }
         });

--- a/app/components/map/services/non-tiled-wms-layer-service.js
+++ b/app/components/map/services/non-tiled-wms-layer-service.js
@@ -179,14 +179,7 @@ angular.module('map')
               // this only works for stores with different aggregation levels
               // for now this is only for the radar stores
               // change image url based on timestate.
-              var store = this._determineStore(timeState);
-              this._temporalResolution = store.resolution;
-              this._imageUrlBase = RasterService.buildURLforWMS(
-                this,
-                map,
-                store.name,
-                timeState.playing
-              );
+              var store = this._determineStore(this.timeState);
 
               this._temporalResolution = store.resolution;
 
@@ -309,15 +302,36 @@ angular.module('map')
              * @param  {object} defer       defer to resolve when done
              */
             _animateSyncTime: function (map, currentDate, defer) {
-              var newBounds = map.getBounds();
+              var newBounds = this._getAnimationBounds(map);
 
               if (this._imageOverlays.length < this._bufferLength
-                || newBounds.getNorth() !== this._bounds.getNorth()
-                || newBounds.getWest() !== this._bounds.getWest()) {
-                // add leaflet layers to fill up the buffer
+                || newBounds.getNorth() !== this._animationBounds.getNorth()
+                || newBounds.getWest() !== this._animationBounds.getWest()) {
+                this._animationBounds = newBounds;
+
+                // add leaflet layers to fill up the buffer and set imageUrlBase
+                // which depends on the bounds of the map and the layer and the
+                // store that corresponds to the timeState.
+
+                var store = this._determineStore(this.timeState);
+
+                var options = {
+                  bounds: this._animationBounds,
+                  size: this._getImageSize(map, this._animationBounds)
+                };
+
+                this._imageUrlBase = RasterService.buildURLforWMS(
+                  this,
+                  map,
+                  store.name,
+                  this.timeState.playing,
+                  options
+                );
+
                 this._imageOverlays = this._createImageOverlays(
                   map,
-                  this._bufferLength
+                  this._bufferLength,
+                  this._animationBounds
                 );
               }
 
@@ -348,19 +362,69 @@ angular.module('map')
              * @param  {int} buffer   amount of imageOverlays to include.
              * @return {array} array of L.imageOverlays.
              */
-            _createImageOverlays: function (map, buffer) {
+            _createImageOverlays: function (map, buffer, bounds) {
               // detach all listeners and references to the imageOverlays.
               this.remove(map);
               // create new ones.
               for (var i = this._imageOverlays.length; i < buffer; i++) {
                 this._imageOverlays.push(
-                  addLeafletLayer(map, LeafletService.imageOverlay('', map.getBounds()))
+                  addLeafletLayer(map, LeafletService.imageOverlay('', bounds))
                 );
               }
-              this._bounds = angular.copy(map.getBounds());
               return this._imageOverlays;
             },
 
+            /**
+             * Takes the bounds of the map and creates an intersection of the
+             * layer and the map for animation.
+             *
+             * @param  {L.Map} map with getBounds
+             * @return {L.LatLngBounds} leaflet bounds of intersection
+             */
+            _getAnimationBounds: function (map) {
+              var mapBounds = map.getBounds();
+
+              var smallestSoutWest = LeafletService.latLng(
+                Math.max(this.bounds.south, mapBounds.getSouth()),
+                Math.max(this.bounds.west, mapBounds.getWest())
+              );
+
+              var smallesNorthEast = LeafletService.latLng(
+                Math.min(this.bounds.north, mapBounds.getNorth()),
+                Math.min(this.bounds.east, mapBounds.getEast())
+              );
+
+              return LeafletService.latLngBounds(
+                smallestSoutWest,
+                smallesNorthEast
+              );
+
+            },
+
+            /**
+             * Determines the pixel size of the imageoverlay on the map.
+             *
+             * @param  {L.Map} map
+             * @param  {L.LatLngBounds} animationBounds intersection of map
+             *                          bounds and layer bounds.
+             *
+             * @return {object with x and y} size in horizontal (x) and
+             *                               vertical (y) direction.
+             */
+            _getImageSize: function (map, animationBounds) {
+              var bottomLeft = map.latLngToContainerPoint(
+                animationBounds.getSouthWest()
+              );
+
+              var topRight = map.latLngToContainerPoint(
+                animationBounds.getNorthEast()
+              );
+
+              return {
+                x : topRight.x - bottomLeft.x,
+                y: bottomLeft.y- topRight.y
+              };
+            },
 
             /**
              * Local helper that returns a rounded timestamp

--- a/app/components/timeline/timeline.html
+++ b/app/components/timeline/timeline.html
@@ -38,14 +38,11 @@
            title="<% timeline.state.temporal.playing ? tooltips.stopAnim : tooltips.startAnim %>"
            data-original-title="<% 'Play/pause' | translate %>">
           <span
-            ng-if="timeline.state.layerGroups.timeIsSyncing"
-            class="fa fa-circle-o-notch fa-spin">
-          </span>
-          <span
-            ng-if="!timeline.state.layerGroups.timeIsSyncing"
+            class="fa"
             ng-class="{
-              'fa fa-pause active': timeline.state.temporal.playing,
-              'fa fa-play': !timeline.state.temporal.playing,
+              'fa-circle-o-notch fa-spin': timeline.state.layerGroups.timeIsSyncing,
+              'fa-pause active': timeline.state.temporal.playing,
+              'fa-play': !timeline.state.temporal.playing && !timeline.state.layerGroups.timeIsSyncing,
               }">
           </span>
         </a>

--- a/app/lib/raster-service.js
+++ b/app/lib/raster-service.js
@@ -62,10 +62,10 @@ angular.module('lizard-nxt')
     };
 
     if (options.geom_id) {
-      requestOptions.geom_id = options.geom_id; 
+      requestOptions.geom_id = options.geom_id;
       requestOptions.boundary_type = options.boundary_type;
     } else {
-      requestOptions.geom = UtilService.geomToWkt(options.geom); 
+      requestOptions.geom = UtilService.geomToWkt(options.geom);
     }
 
     if (options.truncate === true) {
@@ -93,32 +93,36 @@ angular.module('lizard-nxt')
    *                              otherwise just 256x256px.
    * @return {string}            url
    */
-  var buildURLforWMS = function (wmsLayer, map, store, singleTile) {
-    var layerName = store || wmsLayer.slug,
-        bounds = map.getBounds(),
+  var buildURLforWMS = function (wmsLayer, map, store, singleTile, options) {
+    var options = options || {},
+        layerName = store || wmsLayer.slug,
+        bounds = options.bounds || map.getBounds(),
         DEFAULT_TILE_SIZE = 256; // in px
 
     var imgBounds = [
       LeafletService.CRS.EPSG3857.project(bounds.getSouthWest()),
       LeafletService.CRS.EPSG3857.project(bounds.getNorthEast()),
     ],
-    opts = wmsLayer.options,
+
+    wmsOpts = wmsLayer.options,
+
     result = wmsLayer.url
       + '?SERVICE=WMS&REQUEST=GetMap&VERSION=1.1.1&FORMAT=image%2Fpng'
       + '&SRS=EPSG%3A3857&LAYERS=' + layerName
       + '&BBOX=' + _buildBbox(imgBounds);
 
     if (singleTile) {
-      var size = map.getPixelBounds().getSize();
-      opts.height = Math.round(size.y / size.x * DEFAULT_TILE_SIZE);
-      opts.width = Math.round(size.x / size.y  * DEFAULT_TILE_SIZE);
+      var size = options.size || map.getPixelBounds().getSize();
+      wmsOpts.height = Math.round(size.y / size.x * DEFAULT_TILE_SIZE);
+      wmsOpts.width = Math.round(size.x / size.y  * DEFAULT_TILE_SIZE);
     } else {
       // Serve square tiles
-      opts.height = DEFAULT_TILE_SIZE;
-      opts.width = DEFAULT_TILE_SIZE;
+      wmsOpts.height = DEFAULT_TILE_SIZE;
+      wmsOpts.width = DEFAULT_TILE_SIZE;
     }
 
-    angular.forEach(opts, function (v, k) {
+
+    angular.forEach(wmsOpts, function (v, k) {
       result += UtilService.buildString('&', k.toUpperCase(), "=", v);
     });
 

--- a/app/lib/raster-service.js
+++ b/app/lib/raster-service.js
@@ -133,18 +133,7 @@ angular.module('lizard-nxt')
     return result;
   };
 
-  var getMinTimeBetweenFrames = function (layerGroup) {
-
-    if (layerGroup.slug === 'rain') {
-      return 100;
-    } else {
-      return 1000;
-    }
-
-  };
-
   return {
-    getMinTimeBetweenFrames: getMinTimeBetweenFrames,
     buildURLforWMS: buildURLforWMS,
     getData: getData,
   };


### PR DESCRIPTION
This improves animation of temporal wms layers. It should be most noticable on *slim* layers, relatively long or wide.

It used to animate the map bounds, now it animates the intersection of map bounds and bounds of the layer as specified in meta.spatial_bounds in lizard-bs.

Pauzing the animation should also be a little bit smoother since the click was not always registered.

This pr should go to fixes so we can deploy it to production before the tenth. I know it is bad practice and it is going to bite us :sob: .