### PR TITLE
Fix: https://github.com/nens/lizard-nxt/issues/1379 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,10 @@ Changelog of lizard-nxt client
 
 Unreleased (2.2.9) (XXXX-XX-XX)
 ---------------------
+
 - Fix pagination for scenarios page.
+
+- Fix WMSGetFeatureInfo bug wrong relative pixel coordinates.
 
 
 Release 2.2.9 (2015-12-16)

--- a/app/lib/wms-get-feature-info-service.js
+++ b/app/lib/wms-get-feature-info-service.js
@@ -45,7 +45,7 @@ angular.module('lizard-nxt')
 
     var size = map.getSize(),
         bbox = map.getBounds().toBBoxString(),
-        point = map.latLngToLayerPoint(options.geom);
+        point = map.latLngToContainerPoint(options.geom);
 
     var params = {
       SERVICE: 'WMS',
@@ -65,7 +65,7 @@ angular.module('lizard-nxt')
 
     var url = layer.url + '/?';
     for (var key in params) {
-        if (url != "") {
+        if (url !== "") {
             url += "&";
         }
         url += key + "=" + params[key];


### PR DESCRIPTION
use container to get relative pixel coordinates for WMSGetFeatureInfo requests.