### PR TITLE
Ernst bugfixes master

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,20 @@ Changelog of lizard-nxt client
 
 Unreleased (2.4.1) (XXXX-XX-XX)
 -------------------------------
--
+
+- Fixed a regression bug in dashboard, tctx is now dashboard.
+
+- Fixed missing parameter referenced unit error in dashboard. It is consistent with the rest, no ts when when the pru is missing.
+
+- Dashboard graphs have a shadow around them and are placed under each other correctly.
+
+- Url sets state for point and multipoint.
+
+- Fixed a bug with spatial.here not cleaned on point scope destroy.
+
+- Fixed a bug with geometry not drawn in multipolygon.
+
+- Sped up the context switch since we no longer need the map to create a dashboard on init.
 
 
 Release 2.5.2 (2015-12-24)

--- a/app/components/dashboard/dashboard-directive.js
+++ b/app/components/dashboard/dashboard-directive.js
@@ -69,7 +69,7 @@ angular.module('dashboard')
       item.data = response.data || response.events;
 
       item.aggWindow = State.temporal.aggWindow;
-      scope.tctx.content[response.layerSlug] = item;
+      scope.dashboard.content[response.layerSlug] = item;
     };
 
     var putEventDataOnScope = function (response) {

--- a/app/components/dashboard/dashboard-directive.js
+++ b/app/components/dashboard/dashboard-directive.js
@@ -19,9 +19,8 @@ angular.module('dashboard')
   var link = function (scope, element, attrs) {
 
     var TL_TOP_MARGIN = 25, // margin plus the temporal.at label
-        GRAPH_PADDING = 5,
+        GRAPH_PADDING = 8,
         GRAPH_5_6th_PADDING_RATIO = 0.83, // The other 6th is used in the css.
-        TOP_ROW_MIN_HEIGHT = 50,
         tlDims = {},
         nGraphs = 1;
 
@@ -32,7 +31,7 @@ angular.module('dashboard')
 
 
     var getHeight = function () {
-      return element.height() - TOP_ROW_MIN_HEIGHT;
+      return element.height();
                                     // min-height from top row, we need to make
                                     // this dynamic or bigger when we are going
                                     // to use the top row for maps etc.
@@ -43,6 +42,7 @@ angular.module('dashboard')
       nGraphs = Object.keys(scope.dashboard.content).length;
       scope.dashboard.dims.height =
         (getHeight() - tlDimensions.height - TL_TOP_MARGIN) / nGraphs - GRAPH_PADDING;
+
       scope.dashboard.dims.width = UtilService.getCurrentWidth() - UtilService.OMNIBOX_WIDTH
         + GRAPH_5_6th_PADDING_RATIO * UtilService.TIMELINE_LEFT_MARGIN;
     };
@@ -70,6 +70,9 @@ angular.module('dashboard')
 
       item.aggWindow = State.temporal.aggWindow;
       scope.dashboard.content[response.layerSlug] = item;
+
+      resize(tlDims);
+
     };
 
     var putEventDataOnScope = function (response) {
@@ -120,6 +123,9 @@ angular.module('dashboard')
             ts.name = ts.location.name
               + ', '
               + ts.parameter_referenced_unit.parameter_short_display_name;
+            ts.unit = ts
+              .parameter_referenced_unit
+              .referenced_unit_short_display_name;
             ts.type = 'timeseries';
             putDataOnScope(ts);
           });
@@ -154,10 +160,6 @@ angular.module('dashboard')
             } else if (State.box.type === 'point' && response.type !== 'Event') {
               putDataOnScope(response);
             }
-          }
-
-          if (tlDims) {
-            resize(tlDims);
           }
 
         });

--- a/app/components/dashboard/dashboard.html
+++ b/app/components/dashboard/dashboard.html
@@ -1,11 +1,6 @@
 <div class="dashboard-wrapper" ng-controller="DashboardCtrl as dashboard">
   <div class="container-fluid">
 
-    <div class="row">
-
-      <div id="dashboard-top-row-place-holder" class="col-md-10 dashboard-inner"></div>
-
-    </div>
     <div class="row" ng-repeat="item in dashboard.content">
 
       <div class="dashboard-inner">

--- a/app/components/omnibox/controllers/multi-point-controller.js
+++ b/app/components/omnibox/controllers/multi-point-controller.js
@@ -251,9 +251,9 @@ angular.module('omnibox')
 
     /**
      * @function
-     * @description Looks at urlState and fills boxes accordingly
+     * @description Looks at State and fills boxes accordingly
      */
-    var changeUrlState = function () {
+    var stateChangeFn = function () {
       $scope.box.content.assets = ($scope.box.content.assets) ? $scope.box.content.assets : [];
       angular.forEach(State.selected.assets, function (asset, i) {
         var entity = asset.split('$')[0];
@@ -277,10 +277,8 @@ angular.module('omnibox')
 
     $scope.$watch(State.toString('selected'), function (n, o) {
       var assetAmount = ($scope.box.content.assets) ? $scope.box.content.assets.length : 0;
-      if (n === o ||
-          (State.selected.assets.length === assetAmount)
-          ) { return ;}
-      changeUrlState();
+      if (State.selected.assets.length === assetAmount) { return ;}
+      stateChangeFn();
     });
 
     $scope.$watch(State.toString('context'), function (n, o) {
@@ -305,8 +303,14 @@ angular.module('omnibox')
       }
     });
 
-    // initially look up from url
-    changeUrlState();
+
+    // Clean up stuff when controller is destroyed
+    $scope.$on('$destroy', function () {
+      DataService.reject('omnibox');
+      $scope.box.content = {};
+      State.selected.reset();
+      ClickFeedbackService.emptyClickLayer(MapService);
+    });
 
   }
 ]);

--- a/app/components/omnibox/controllers/multi-point-controller.js
+++ b/app/components/omnibox/controllers/multi-point-controller.js
@@ -289,7 +289,7 @@ angular.module('omnibox')
         $scope.box.content.assets.forEach(function (asset) {
           var feature = {
             type: 'Feature',
-            geometry: angular.fromJson(asset.data.geom),
+            geometry: angular.fromJson(asset.data.geometry),
             properties: {
               entity_name: asset.data.entity_name,
               type: asset.data.type || ''

--- a/app/components/omnibox/controllers/point-controller.js
+++ b/app/components/omnibox/controllers/point-controller.js
@@ -198,7 +198,7 @@ angular.module('omnibox')
     $scope.$on('$destroy', function () {
       DataService.reject('omnibox');
       $scope.box.content = {};
-      State.spatial.points = [];
+      State.spatial.here = [];
       ClickFeedbackService.emptyClickLayer(MapService);
     });
   }

--- a/app/components/timeseries/timeseries-service.js
+++ b/app/components/timeseries/timeseries-service.js
@@ -104,6 +104,8 @@ angular.module('timeseries')
             layerSlug: 'timeseries',
           });
         }
+
+        response.results = filteredResult;
         return response; // accomadate chaining.
       });
 

--- a/app/components/timeseries/timeseries-service.js
+++ b/app/components/timeseries/timeseries-service.js
@@ -68,8 +68,12 @@ angular.module('timeseries')
         angular.forEach(response.results, function (ts) {
           var msg = '';
           if (ts.events.length > 1 &&
-              ts.events.length < MAX_NR_TIMESERIES_EVENTS &&
-              ts.parameter_referenced_unit) {
+              ts.events.length < MAX_NR_TIMESERIES_EVENTS) {
+
+            if (ts.parameter_referenced_unit === null) {
+              ts.parameter_referenced_unit = {};
+            }
+
             filteredResult.push(ts);
 
           // Else: output a message to the console and an error to sentry.

--- a/app/components/url/url-controller.js
+++ b/app/components/url/url-controller.js
@@ -324,11 +324,11 @@ angular.module('lizard-nxt')
       }
 
       if (geom) {
-        if (boxType === 'multi-point') {
-          State.selected = UrlState.parseGeom(State.box.type, geom, State.selected);
-        } else if (/\d/.test(geom)) {
+        if (geom.split('$').length === 1) {
           State.spatial = UrlState.parseGeom(State.box.type, geom, State.spatial);
-        } else {
+        } else if (boxType === 'point' || boxType === 'multi-point') {
+          State.selected = UrlState.parseGeom(State.box.type, geom, State.selected);
+        } else if (boxType === 'region') {
           NxtRegionsLayer.setActiveRegion(geom);
         }
       }

--- a/app/components/url/url-service.js
+++ b/app/components/url/url-service.js
@@ -283,27 +283,33 @@ angular.module('lizard-nxt')
           return false;
         }
       },
-      parseGeom: function (type, geom, mapState) {
-        if (type === 'point') {
-          var point = geom.split(',');
-          if (parseFloat(point[0]) &&
-              parseFloat(point[1])) {
-            mapState.here = L.latLng(point[0], point[1]);
-          }
-        } else if (type === 'line') {
+
+      parseGeom: function (type, geom, state) {
+        var point = geom.split(',');
+        if (type === 'point'
+          && point.length > 1
+          && parseFloat(point[0])
+          && parseFloat(point[1])) {
+          state.here = L.latLng(point[0], point[1]);
+        }
+
+        else if (type === 'line') {
           var points = geom.split('-');
           angular.forEach(points, function (pointStr, key) {
             var point = pointStr.split(',');
             if (parseFloat(point[0]) &&
                 parseFloat(point[1])) {
-              mapState.points[key] = L.latLng(point[0], point[1]);
+              state.points[key] = L.latLng(point[0], point[1]);
             }
           });
-        } else if (type === 'multi-point') {
-          var items = geom.split(',');
-          mapState.assets = items;
         }
-        return mapState;
+
+        else if (type === 'multi-point' || 'point') {
+          var items = geom.split(',');
+          state.assets = items;
+        }
+
+        return state;
       },
       update: function (state) {
         var u = true;

--- a/app/lizard-nxt-master-controller.js
+++ b/app/lizard-nxt-master-controller.js
@@ -56,20 +56,21 @@ angular.module('lizard-nxt')
   $scope.transitionToContext = function (context) {
     if (context !== State.context) {
       var overlay = angular.element('#context-transition-overlay')[0];
+      overlay.style.transition = null;
       overlay.style.minHeight = window.innerHeight + 'px';
-      overlay.style.transition = 'ease .3s';
       $timeout(function () {
+        overlay.style.transition = 'ease .3s';
         overlay.style.opacity = 1;
-      }, 300);
+      }, 10);
       $timeout(function () {
         State.context = context;
         $scope.context = State.context;
         overlay.style.opacity = 0;
-      }, 600, true);
+      }, 300);
       $timeout(function () {
         overlay.style.transition = null;
         overlay.style.minHeight = 0;
-      }, 900);
+      }, 600, true);
     }
   };
 

--- a/app/styles/_dashboard.scss
+++ b/app/styles/_dashboard.scss
@@ -3,21 +3,32 @@
  */
 
 .dashboard-wrapper {
-  transition: .3s ease;
-  height: 100%;
-  width: 100%;
   position: absolute;
+  top: $navbarheight;
+  left: $omnibox-width;
+  bottom: 0;
   overflow: hidden;
-  background-color: $clouds;
+  transition: .3s ease;
 }
 
 .dashboard-wrapper .row {
   min-height: 50px;
-  margin: 0;
-  padding-left: 10px
+  margin: 3px;
+  padding: 5px;
+  @include material-shadow();
+
+  &:hover {
+    @include material-shadow-hover();
+  }
+
+  &:first-child {
+    /*
+      We probably want to increase this to have it nicely under the navbar
+      alligning with the cards.
+    */
+    margin-top: 1px;
+  }
 }
 
 .dashboard-inner {
-  position: absolute;
-  left: $omnibox-width; /* graph starts next to omnibox */
 }


### PR DESCRIPTION
- [x] Fixed a regression bug in dashboard, tctx is now dashboard.
- [ ] If PRU is missing make an empty one in timeseries-service
- [x] Dashboard graphs have a shadow around them and are placed under each other correctly.
- [x] Url sets state for point and multipoint.
- [x] Fixed a bug with spatial.here not cleaned on destroy.
- [x] fixed a bug with geometry not drawn in multipolygon.
- [x] Sped up the context switch since we no longer need the map to create a dashboard on init.

It looks like this:

![image](https://cloud.githubusercontent.com/assets/4438154/12111304/7ecfa744-b394-11e5-96c6-aeb280e48c0a.png)

Open for other pr:

- [ ] Make single point use api when entity name and id are known.
- [ ] Redo dashboard cards.