### PR TITLE
Imagemin was removed because of reasons, now it's back

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -358,6 +358,18 @@ module.exports = function (grunt) {
       }
     },
 
+    imagemin: {
+      dist: {
+        files: [{
+          expand: true,
+          cwd: '<%= yeoman.app %>/images',
+          src: '{,*/}*.{png,jpg,jpeg,gif}',
+          dest: '<%= yeoman.dist %>/images'
+        }]
+      }
+    },
+
+
     svgmin: {
       dist: {
         files: [{
@@ -516,6 +528,7 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-contrib-clean');
     grunt.loadNpmTasks('grunt-contrib-copy');
     grunt.loadNpmTasks('grunt-usemin');
+    grunt.loadNpmTasks('grunt-contrib-imagemin');
     grunt.loadNpmTasks('grunt-svgmin');
     grunt.loadNpmTasks('grunt-contrib-concat');
     grunt.loadNpmTasks('grunt-ng-annotate');
@@ -530,6 +543,7 @@ module.exports = function (grunt) {
       'wiredep',
       'useminPrepare',
       'sass',
+      'imagemin',
       'copy:styles',
       'autoprefixer',
       'svgmin',

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "grunt-contrib-connect": "^0.7.1",
     "grunt-contrib-copy": "^0.5.0",
     "grunt-contrib-cssmin": "^0.9.0",
+    "grunt-contrib-imagemin": "^1.0.0",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-filerev": "^0.2.1",


### PR DESCRIPTION
Imagemin is the image crusher we use to make our image files
smaller. The dependency was removed was somewhere along the way.

That meant that no images were being copied to the dist/images folder.
So:
* No favicon
* Some structures icons went missing: [weir](https://demo.lizard.net/static/client/images/weir.png)

Hopefully this will also lay to rest @byrman whining about favicons :kissing_closed_eyes: 