### PR TITLE
Restyle Search Box

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,10 @@ Unreleased (2.6.2) (XXXX-XX-XX)
 
 - Restyle the user menu.
 
+- Restyle the search box.
+
+- Fix bugs in zoom buttons, openLayerGroups and clearing of the search query.
+
 
 Release 2.6.2 (2016-1-18)
 ---------------------

--- a/app/components/omnibox/directives/search-directive.js
+++ b/app/components/omnibox/directives/search-directive.js
@@ -68,10 +68,10 @@ angular.module('omnibox')
      * @param {object} search result with layergroup.
      * simple pointer to SearchService functio
      */
-    scope.openLayerGroup = function () {
+    scope.openLayerGroup = function (lg) {
       scope.query = "";
       scope.omnibox.searchResults = {};
-      SearchService.openLayerGroup
+      SearchService.openLayerGroup(lg);
     };
 
     /**

--- a/app/components/omnibox/directives/search-directive.js
+++ b/app/components/omnibox/directives/search-directive.js
@@ -22,6 +22,10 @@ angular.module('omnibox')
     // Set focus on search input field.
     element.children()[0].focus();
 
+    // Bind mapservice functions for zoom buttons;
+    scope.zoomIn = MapService.zoomIn;
+    scope.zoomOut = MapService.zoomOut;
+
     /**
      * Uses scope.query to search for results through SearchService. Response
      * from SearchService.search is an object with various results and promises.

--- a/app/components/omnibox/directives/search-directive.js
+++ b/app/components/omnibox/directives/search-directive.js
@@ -57,7 +57,7 @@ angular.module('omnibox')
      */
     scope.cleanInput = function () {
       State.selected.reset();
-      scope.omnibox.query = "";
+      scope.query = "";
       scope.omnibox.searchResults = {};
     };
 
@@ -69,7 +69,7 @@ angular.module('omnibox')
      * simple pointer to SearchService functio
      */
     scope.openLayerGroup = function () {
-      scope.omnibox.query = "";
+      scope.query = "";
       scope.omnibox.searchResults = {};
       SearchService.openLayerGroup
     };
@@ -87,7 +87,7 @@ angular.module('omnibox')
         zoom: ZOOM_FOR_OBJECT
       });
       scope.omnibox.searchResults = {};
-      scope.omnibox.query = "";
+      scope.query = "";
     };
 
     /**
@@ -96,7 +96,7 @@ angular.module('omnibox')
      */
     scope.zoomToSpatialResult = function (result, origin) {
       scope.omnibox.searchResults = {};
-      scope.omnibox.query = "";
+      scope.query = "";
       State = SearchService.zoomToGoogleGeocoderResult(result, State);
     };
 
@@ -108,7 +108,7 @@ angular.module('omnibox')
      */
     scope.zoomToTemporalResult = function(m) {
       scope.omnibox.searchResults = {};
-      scope.omnibox.query = "";
+      scope.query = "";
       State.temporal.start = m.valueOf();
       State.temporal.end = m.valueOf() + m.nxtInterval.valueOf();
       UtilService.announceMovedTimeline(State);

--- a/app/components/omnibox/templates/search-results.html
+++ b/app/components/omnibox/templates/search-results.html
@@ -9,6 +9,7 @@
     <ul>
       <li ng-cloak
         ng-repeat="result in omnibox.searchResults.spatial"
+        tabindex="2"
         class="cluster location">
         <a ng-click="zoomToSpatialResult(result)"
           class="pointer clickable">
@@ -24,6 +25,7 @@
     <ul>
       <li ng-cloak
         ng-repeat="result in omnibox.searchResults.timeseries"
+        tabindex="2"
         class="cluster location">
         <a ng-click="zoomToSearchResult(result, 'timeseries')"
           class="pointer clickable">
@@ -38,6 +40,7 @@
     </h3>
     <ul>
       <li ng-cloak
+        tabindex="2"
         ng-repeat="result in omnibox.searchResults.layergroups"
         class="cluster location">
         <a ng-click="openLayerGroup(result)"

--- a/app/components/omnibox/templates/search-results.html
+++ b/app/components/omnibox/templates/search-results.html
@@ -12,7 +12,7 @@
         class="cluster location">
         <a ng-click="zoomToSpatialResult(result)"
           tabindex="2"
-          href="#">
+          href="">
           <span><% result.formatted_address %></span>
         </a>
       </li>
@@ -28,7 +28,7 @@
         class="cluster location">
         <a ng-click="zoomToSearchResult(result, 'timeseries')"
           tabindex="2"
-          href="#">
+          href="">
           <span><% result.location.name %> - <% result.name %></span>
         </a>
       </li>
@@ -44,7 +44,7 @@
         class="cluster location">
         <a ng-click="openLayerGroup(result)"
           tabindex="2"
-          href="#">
+          href="">
           <span><% result.name %></span>
         </a>
       </li>

--- a/app/components/omnibox/templates/search-results.html
+++ b/app/components/omnibox/templates/search-results.html
@@ -9,10 +9,10 @@
     <ul>
       <li ng-cloak
         ng-repeat="result in omnibox.searchResults.spatial"
-        tabindex="2"
         class="cluster location">
         <a ng-click="zoomToSpatialResult(result)"
-          class="pointer clickable">
+          tabindex="2"
+          href="#">
           <span><% result.formatted_address %></span>
         </a>
       </li>
@@ -25,10 +25,10 @@
     <ul>
       <li ng-cloak
         ng-repeat="result in omnibox.searchResults.timeseries"
-        tabindex="2"
         class="cluster location">
         <a ng-click="zoomToSearchResult(result, 'timeseries')"
-          class="pointer clickable">
+          tabindex="2"
+          href="#">
           <span><% result.location.name %> - <% result.name %></span>
         </a>
       </li>
@@ -40,11 +40,11 @@
     </h3>
     <ul>
       <li ng-cloak
-        tabindex="2"
         ng-repeat="result in omnibox.searchResults.layergroups"
         class="cluster location">
         <a ng-click="openLayerGroup(result)"
-          class="pointer clickable">
+          tabindex="2"
+          href="#">
           <span><% result.name %></span>
         </a>
       </li>

--- a/app/components/omnibox/templates/search.html
+++ b/app/components/omnibox/templates/search.html
@@ -1,35 +1,39 @@
 <div class="searchbox" id="searchbox" tabindex="-1" role="search">
-
-  <div class="searchboxinput">
-    <input id="searchboxinput"
-      ng-change="search()"
-      tabindex="-1"
-      placeholder="<% 'Search for places, or dates (i.e. 23-10-2013)' | translate %>"
-      autocomplete="off"
-      dir="ltr"
-      ng-model="query"
-      ng-keydown="searchKeyPress($event)"
-      spellcheck="false">
-    <div
-      title="<% tooltips.resetQuery %>"
-      ng-click="cleanInput()"
-      id="clear" class="clickable"></div>
-    <div class="search-button-collection">
-      <a
-        class="searchbutton clickable"
-        ng-click="zoomIn()"
-        aria-label="Zoom in"
-        title="<% tooltips.zoomInMap %>">
-        <i class="fa fa-plus"></i>
-      </a>
-      <a
-        class="searchbutton clickable"
-        ng-click="zoomOut()"
-        aria-label="Zoom uit"
-        title="<% tooltips.zoomOutMap %>">
-        <i class="fa fa-minus"></i>
-      </a>
-    </div>
+  <div class="zoom-buttons material-shadow">
+    <button class="btn btn-primary"
+            ng-click="zoomIn()"
+            aria-label="<% tooltips.zoomInMap %>">
+      <i class="fa fa-plus"></i>
+    </button>
+    <button class="btn btn-primary"
+            ng-click="zoomOut()"
+            aria-label="<% tooltips.zoomOutMap %>">
+      <i class="fa fa-minus"></i>
+    </button>
   </div>
 
+  <div class="resize-wrapper material-shadow">
+    <div class="search-and-close">
+      <button class="btn btn-default btn-lg clear-search"
+              type="button"
+              aria-label="<% tooltips.resetQuery %>"
+              ng-click="cleanInput()"
+              id="clear">
+        <i class="fa fa-close"></i>
+      </button>
+      <div class="resize-wrapper">
+        <input
+          id="searchboxinput"
+          ng-change="search()"
+          tabindex="-1"
+          placeholder="<% 'Search for places, or dates (i.e. 23-10-2013)' | translate %>"
+          autocomplete="off"
+          dir="ltr"
+          ng-model="query"
+          ng-keydown="searchKeyPress($event)"
+          spellcheck="false"
+          type="search">
+      </div>
+    </div>
+  </div>
 </div>

--- a/app/components/omnibox/templates/search.html
+++ b/app/components/omnibox/templates/search.html
@@ -18,6 +18,7 @@
               type="button"
               aria-label="<% tooltips.resetQuery %>"
               ng-click="cleanInput()"
+              ng-if="query"
               id="clear">
         <i class="fa fa-close"></i>
       </button>

--- a/app/components/omnibox/templates/search.html
+++ b/app/components/omnibox/templates/search.html
@@ -2,11 +2,15 @@
   <div class="zoom-buttons material-shadow">
     <button class="btn btn-primary"
             ng-click="zoomIn()"
+            tabindex="4"
+            accesskey="+"
             aria-label="<% tooltips.zoomInMap %>">
       <i class="fa fa-plus"></i>
     </button>
     <button class="btn btn-primary"
             ng-click="zoomOut()"
+            tabindex="4"
+            accesskey="-"
             aria-label="<% tooltips.zoomOutMap %>">
       <i class="fa fa-minus"></i>
     </button>
@@ -19,6 +23,8 @@
               aria-label="<% tooltips.resetQuery %>"
               ng-click="cleanInput()"
               ng-if="query"
+              tabindex="3"
+              accesskey="q"
               id="clear">
         <i class="fa fa-close"></i>
       </button>
@@ -26,7 +32,8 @@
         <input
           id="searchboxinput"
           ng-change="search()"
-          tabindex="-1"
+          tabindex="1"
+          accesskey="s"
           placeholder="<% 'Search for places, or dates (i.e. 23-10-2013)' | translate %>"
           autocomplete="off"
           dir="ltr"

--- a/app/components/user-menu/user-menu.html
+++ b/app/components/user-menu/user-menu.html
@@ -13,6 +13,7 @@
         <a ng-click="toggleDashboard()"
            title="<% 'Switch to dashboard' | translate %>"
            target="_blank"
+           accesskey="d"
            href="">
           <i class="fa fa-bar-chart"></i>
           <span translate>Dashboard</span>
@@ -23,6 +24,7 @@
            ng-click="toggleDashboard()"
            title="<% 'Switch to map' | translate %>"
            target="_blank"
+           accesskey="m"
            href="">
           <i class="fa fa-globe"></i>
           <span translate>Map</span>

--- a/app/styles/_omnibox.scss
+++ b/app/styles/_omnibox.scss
@@ -502,7 +502,7 @@ table tr td:last-child {
     top: 9px;
     width: 390px;
     padding-left: 9px;
-    color: white;
+    color: $white;
     line-height: 1;
 
     .icons {

--- a/app/styles/_omnibox.scss
+++ b/app/styles/_omnibox.scss
@@ -41,102 +41,8 @@
     }
 }
 
-.searchbox {
-    background: $white;
-    background: rgba($white, 0.95);
-    border: 1px solid transparent;
-    border-right: 0;
-    border-radius: 2px 0 0 2px;
-    box-sizing: border-box;
-    height: 32px;
-    outline: none;
-    padding: 0 11px 0 13px;
-    width: 462px; // width plus zoom buttons
-
-    @include material-shadow();
-
-    &:hover {
-        @include material-shadow-hover();
-    }
-}
-
-.cards-minimized .searchbox-shadow {
-    box-shadow: 0 2px 6px rgba($black, 0.3),0 4px 15px -5px rgba($black, 0.3);
-}
-
-.searchboxinput {
-    width: 375px;
-    padding: 0px;
-}
-
-#clear {
-    width: 16px;
-    height: 16px;
-    display: inline-block;
-    background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAACXBIWXMAAAsTAAALEwEAmpwYAAAKT2lDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjanVNnVFPpFj333vRCS4iAlEtvUhUIIFJCi4AUkSYqIQkQSoghodkVUcERRUUEG8igiAOOjoCMFVEsDIoK2AfkIaKOg6OIisr74Xuja9a89+bN/rXXPues852zzwfACAyWSDNRNYAMqUIeEeCDx8TG4eQuQIEKJHAAEAizZCFz/SMBAPh+PDwrIsAHvgABeNMLCADATZvAMByH/w/qQplcAYCEAcB0kThLCIAUAEB6jkKmAEBGAYCdmCZTAKAEAGDLY2LjAFAtAGAnf+bTAICd+Jl7AQBblCEVAaCRACATZYhEAGg7AKzPVopFAFgwABRmS8Q5ANgtADBJV2ZIALC3AMDOEAuyAAgMADBRiIUpAAR7AGDIIyN4AISZABRG8lc88SuuEOcqAAB4mbI8uSQ5RYFbCC1xB1dXLh4ozkkXKxQ2YQJhmkAuwnmZGTKBNA/g88wAAKCRFRHgg/P9eM4Ors7ONo62Dl8t6r8G/yJiYuP+5c+rcEAAAOF0ftH+LC+zGoA7BoBt/qIl7gRoXgugdfeLZrIPQLUAoOnaV/Nw+H48PEWhkLnZ2eXk5NhKxEJbYcpXff5nwl/AV/1s+X48/Pf14L7iJIEyXYFHBPjgwsz0TKUcz5IJhGLc5o9H/LcL//wd0yLESWK5WCoU41EScY5EmozzMqUiiUKSKcUl0v9k4t8s+wM+3zUAsGo+AXuRLahdYwP2SycQWHTA4vcAAPK7b8HUKAgDgGiD4c93/+8//UegJQCAZkmScQAAXkQkLlTKsz/HCAAARKCBKrBBG/TBGCzABhzBBdzBC/xgNoRCJMTCQhBCCmSAHHJgKayCQiiGzbAdKmAv1EAdNMBRaIaTcA4uwlW4Dj1wD/phCJ7BKLyBCQRByAgTYSHaiAFiilgjjggXmYX4IcFIBBKLJCDJiBRRIkuRNUgxUopUIFVIHfI9cgI5h1xGupE7yAAygvyGvEcxlIGyUT3UDLVDuag3GoRGogvQZHQxmo8WoJvQcrQaPYw2oefQq2gP2o8+Q8cwwOgYBzPEbDAuxsNCsTgsCZNjy7EirAyrxhqwVqwDu4n1Y8+xdwQSgUXACTYEd0IgYR5BSFhMWE7YSKggHCQ0EdoJNwkDhFHCJyKTqEu0JroR+cQYYjIxh1hILCPWEo8TLxB7iEPENyQSiUMyJ7mQAkmxpFTSEtJG0m5SI+ksqZs0SBojk8naZGuyBzmULCAryIXkneTD5DPkG+Qh8lsKnWJAcaT4U+IoUspqShnlEOU05QZlmDJBVaOaUt2ooVQRNY9aQq2htlKvUYeoEzR1mjnNgxZJS6WtopXTGmgXaPdpr+h0uhHdlR5Ol9BX0svpR+iX6AP0dwwNhhWDx4hnKBmbGAcYZxl3GK+YTKYZ04sZx1QwNzHrmOeZD5lvVVgqtip8FZHKCpVKlSaVGyovVKmqpqreqgtV81XLVI+pXlN9rkZVM1PjqQnUlqtVqp1Q61MbU2epO6iHqmeob1Q/pH5Z/YkGWcNMw09DpFGgsV/jvMYgC2MZs3gsIWsNq4Z1gTXEJrHN2Xx2KruY/R27iz2qqaE5QzNKM1ezUvOUZj8H45hx+Jx0TgnnKKeX836K3hTvKeIpG6Y0TLkxZVxrqpaXllirSKtRq0frvTau7aedpr1Fu1n7gQ5Bx0onXCdHZ4/OBZ3nU9lT3acKpxZNPTr1ri6qa6UbobtEd79up+6Ynr5egJ5Mb6feeb3n+hx9L/1U/W36p/VHDFgGswwkBtsMzhg8xTVxbzwdL8fb8VFDXcNAQ6VhlWGX4YSRudE8o9VGjUYPjGnGXOMk423GbcajJgYmISZLTepN7ppSTbmmKaY7TDtMx83MzaLN1pk1mz0x1zLnm+eb15vft2BaeFostqi2uGVJsuRaplnutrxuhVo5WaVYVVpds0atna0l1rutu6cRp7lOk06rntZnw7Dxtsm2qbcZsOXYBtuutm22fWFnYhdnt8Wuw+6TvZN9un2N/T0HDYfZDqsdWh1+c7RyFDpWOt6azpzuP33F9JbpL2dYzxDP2DPjthPLKcRpnVOb00dnF2e5c4PziIuJS4LLLpc+Lpsbxt3IveRKdPVxXeF60vWdm7Obwu2o26/uNu5p7ofcn8w0nymeWTNz0MPIQ+BR5dE/C5+VMGvfrH5PQ0+BZ7XnIy9jL5FXrdewt6V3qvdh7xc+9j5yn+M+4zw33jLeWV/MN8C3yLfLT8Nvnl+F30N/I/9k/3r/0QCngCUBZwOJgUGBWwL7+Hp8Ib+OPzrbZfay2e1BjKC5QRVBj4KtguXBrSFoyOyQrSH355jOkc5pDoVQfujW0Adh5mGLw34MJ4WHhVeGP45wiFga0TGXNXfR3ENz30T6RJZE3ptnMU85ry1KNSo+qi5qPNo3ujS6P8YuZlnM1VidWElsSxw5LiquNm5svt/87fOH4p3iC+N7F5gvyF1weaHOwvSFpxapLhIsOpZATIhOOJTwQRAqqBaMJfITdyWOCnnCHcJnIi/RNtGI2ENcKh5O8kgqTXqS7JG8NXkkxTOlLOW5hCepkLxMDUzdmzqeFpp2IG0yPTq9MYOSkZBxQqohTZO2Z+pn5mZ2y6xlhbL+xW6Lty8elQfJa7OQrAVZLQq2QqboVFoo1yoHsmdlV2a/zYnKOZarnivN7cyzytuQN5zvn//tEsIS4ZK2pYZLVy0dWOa9rGo5sjxxedsK4xUFK4ZWBqw8uIq2Km3VT6vtV5eufr0mek1rgV7ByoLBtQFr6wtVCuWFfevc1+1dT1gvWd+1YfqGnRs+FYmKrhTbF5cVf9go3HjlG4dvyr+Z3JS0qavEuWTPZtJm6ebeLZ5bDpaql+aXDm4N2dq0Dd9WtO319kXbL5fNKNu7g7ZDuaO/PLi8ZafJzs07P1SkVPRU+lQ27tLdtWHX+G7R7ht7vPY07NXbW7z3/T7JvttVAVVN1WbVZftJ+7P3P66Jqun4lvttXa1ObXHtxwPSA/0HIw6217nU1R3SPVRSj9Yr60cOxx++/p3vdy0NNg1VjZzG4iNwRHnk6fcJ3/ceDTradox7rOEH0x92HWcdL2pCmvKaRptTmvtbYlu6T8w+0dbq3nr8R9sfD5w0PFl5SvNUyWna6YLTk2fyz4ydlZ19fi753GDborZ752PO32oPb++6EHTh0kX/i+c7vDvOXPK4dPKy2+UTV7hXmq86X23qdOo8/pPTT8e7nLuarrlca7nuer21e2b36RueN87d9L158Rb/1tWeOT3dvfN6b/fF9/XfFt1+cif9zsu72Xcn7q28T7xf9EDtQdlD3YfVP1v+3Njv3H9qwHeg89HcR/cGhYPP/pH1jw9DBY+Zj8uGDYbrnjg+OTniP3L96fynQ89kzyaeF/6i/suuFxYvfvjV69fO0ZjRoZfyl5O/bXyl/erA6xmv28bCxh6+yXgzMV70VvvtwXfcdx3vo98PT+R8IH8o/2j5sfVT0Kf7kxmTk/8EA5jz/GMzLdsAAAAgY0hSTQAAeiUAAICDAAD5/wAAgOkAAHUwAADqYAAAOpgAABdvkl/FRgAAAG1JREFUeNrM1EsKwCAMRdEHbtoNuYK7wHTSQaH5TB6lgrN4JIlRESHHlh0CNnCApWEB647dGXSAmLAHEsDJoDVhWcwLqgI7RJJSqDrQXVBCBVam3EIJVtbtG8iSmqXYlvbbHqRzRDxD+5v/6BoANE6rI5kJCPcAAAAASUVORK5CYII=');
-    background-repeat: no-repeat;
-    position: relative;
-    left: 360px;
-    top: -24px;
-}
-
-.search-button-collection {
-    height: 32px;
-    left: 400px;
-    width: 62px;
-    position: absolute;
-    text-align: center;
-    top: 0;
-    vertical-align: top;
-}
-
-.searchbutton {
-    position: relative;
-    float: left;
-    padding: 6px 10px;
-    background-color: $greenSea;
-    border: 0;
-    color: $white;
-    -webkit-user-select: none;  /* Chrome all / Safari all */
-    -moz-user-select: none;     /* Firefox all */
-    -ms-user-select: none;
-    user-select: none;
-    &:hover {
-        color: $white;
-        background-color: $turquoise;
-        @include material-shadow-hover();
-    }
-}
-
-
-.searchbutton::before {
-    display: block;
-    height: 17px;
-    margin: 0 auto;
-    width: 17px;
-}
-
-.searchbox input::-webkit-input-speech-button {
-    opacity: 0.5;
-}
-
 #rap-card {
     outline: none;
-}
-
-.searchbox input {
-    vertical-align: middle;
-    background-color: transparent;
-    border: 0;
-    font-size: 14px;
-    font-weight: 300;
-    margin: 0;
-    outline: 0;
-    padding: 0;
-    width: 100%;
-    box-shadow: none;
-    height: 30px;
-    color: $asbestos;
 }
 
 #cards {
@@ -285,27 +191,6 @@
     padding-left:20px;
 }
 
-.search-results > ul {
-    padding: 0;
-    margin: 0;
-}
-
-.search-results > ul > li:hover {
-    background-color: $clouds;
-}
-
-.search-results > ul > li:last {
-    margin-bottom: 5px;
-}
-
-.search-results > h3 {
-    background-color: $turquoise;
-    font-size: 14px;
-    padding: 10px;
-    color: $white;
-    margin: 0;
-}
-
 .clickable{
     cursor: pointer;
 }
@@ -321,32 +206,6 @@
     margin-bottom: 5px;
     opacity: 1;
     transition: all 200ms cubic-bezier(0.52,0,0.48,1);
-}
-
-.results-shadow {
-    box-shadow: 0 2px 6px rgba($black, 0.3),0 4px 15px -5px rgba($black, 0.0);
-    transition: all 200ms cubic-bezier(0.52,0,0.48,1);
-}
-
-#results {
-    color: $deprecated-color1;
-    -webkit-transform: translateZ(0);
-    transform: translateZ(0);
-    padding: 15px;
-    top: 0;
-    z-index: 9;
-    width: 370px;
-    outline: none;
-    position: absolute;
-    background: $white;
-    margin-top: 11px;
-    margin-left: 16px;
-    transition: opacity 200ms cubic-bezier(0.52,0,0.48,1);
-    opacity: 1;
-}
-
-#results ul li {
-    list-style-image:url('img/globe-icon.png');
 }
 
 .nav a{

--- a/app/styles/_searchbox.scss
+++ b/app/styles/_searchbox.scss
@@ -1,21 +1,25 @@
+$searchbox-height: 50px;
+$searchbox-margins: 10px;
+$zoombutton-width: 30px;
+
 .searchbox {
-    height: 50px;
-    margin-bottom: 10px;
+    height: $searchbox-height;
+    margin-bottom: $searchbox-margins;
 
     .resize-wrapper {
         overflow: hidden;
     }
 
     .search-and-close {
-        height: 50px;
+        height: $searchbox-height;
         width: 100%;
         background: $white;
         background: rgba($white, 0.95);
 
         input {
-            height: 30px;
+            height: $searchbox-height - (2 * $searchbox-margins);
             width: 100%;
-            margin-top: 10px;
+            margin-top: $searchbox-margins;
             padding: 0 15px;
             background: transparent;
             color: $asbestos;
@@ -32,8 +36,8 @@
 
         .clear-search {
             float: right;
-            height: 50px;
-            width: 50px;
+            height: $searchbox-height;
+            width: $searchbox-height;
             background: transparent;
             color: $silver;
             border-radius: 0;
@@ -45,11 +49,14 @@
 
             &:after {
                 content: '';
-                height: 30px;
+                height: $searchbox-height - (2 * $searchbox-margins);
                 border-left: 1px solid $silver;
                 position: absolute;
-                top: 10px;
-                right: 90px;
+                // Position absolute sets the the border on the right of the
+                // zoom buttons if right=0 (or left of the search bar if
+                // left=0). Move it to left of the close button.
+                right: $zoombutton-width + $searchbox-margins + $searchbox-height;
+                top: $searchbox-margins;
             }
         }
     }
@@ -57,14 +64,14 @@
 
 .zoom-buttons {
     float: right;
-    height: 50px;
-    margin-left: 10px;
+    height: $searchbox-height;
+    margin-left: $searchbox-margins;
     text-align: center;
 
     button {
         display: block;
-        height: 25px;
-        width: 30px;
+        height: $searchbox-height / 2;
+        width: $zoombutton-width;
         padding: 0;
         background-color: $greenSea;
         color: $white;
@@ -83,7 +90,7 @@
     > h3 {
         background-color: $turquoise;
         font-size: 14px;
-        padding: 10px;
+        padding: $searchbox-margins;
         color: $white;
         margin: 0;
     }

--- a/app/styles/_searchbox.scss
+++ b/app/styles/_searchbox.scss
@@ -78,10 +78,13 @@ $zoombutton-width: 30px;
         border: none;
         border-radius: 0;
 
-        &:hover {
+        &:hover, &:active {
             color: $white;
             background-color: $turquoise;
             @include material-shadow-hover();
+        }
+        &:focus {
+            background-color: $greenSea;
         }
     }
 }

--- a/app/styles/_searchbox.scss
+++ b/app/styles/_searchbox.scss
@@ -1,78 +1,81 @@
 .searchbox {
-    background: $white;
-    background: rgba($white, 0.95);
-    border: 1px solid transparent;
-    border-right: 0;
-    border-radius: 2px 0 0 2px;
-    box-sizing: border-box;
-    height: 32px;
-    outline: none;
-    padding: 0 11px 0 13px;
-    width: 462px; // width plus zoom buttons
-    @include material-shadow();
+    height: 50px;
+    margin-bottom: 10px;
 
-    &:hover {
-        @include material-shadow-hover();
+    .resize-wrapper {
+        overflow: hidden;
     }
 
-    input {
-        vertical-align: middle;
-        background-color: transparent;
-        border: 0;
-        font-size: 14px;
-        font-weight: 300;
-        margin: 0;
-        outline: 0;
-        padding: 0;
+    .search-and-close {
+        height: 50px;
         width: 100%;
-        box-shadow: none;
-        height: 30px;
-        color: $asbestos;
+        background: $white;
+        background: rgba($white, 0.95);
 
-        &::-webkit-input-speech-button {
-            opacity: 0.5;
+        input {
+            height: 30px;
+            width: 100%;
+            margin-top: 10px;
+            padding: 0 15px;
+            background: transparent;
+            color: $asbestos;
+            border: none;
+            &:focus {
+                // Remove the border on focus for Webkit/Chrome.
+                outline: none;
+            }
+
+            &::-webkit-input-speech-button {
+                opacity: 0.5;
+            }
+        }
+
+        .clear-search {
+            float: right;
+            height: 50px;
+            width: 50px;
+            background: transparent;
+            color: $silver;
+            border-radius: 0;
+            border: none;
+
+            &:hover {
+                color: $asbestos;
+            }
+
+            &:after {
+                content: '';
+                height: 30px;
+                border-left: 1px solid $silver;
+                position: absolute;
+                top: 10px;
+                right: 90px;
+            }
         }
     }
 }
 
-.searchboxinput {
-    width: 375px;
-    padding: 0px;
-}
-
-.search-button-collection {
-    height: 32px;
-    left: 400px;
-    width: 62px;
-    position: absolute;
+.zoom-buttons {
+    float: right;
+    height: 50px;
+    margin-left: 10px;
     text-align: center;
-    top: 0;
-    vertical-align: top;
-}
 
-.searchbutton {
-    position: relative;
-    float: left;
-    padding: 6px 10px;
-    background-color: $greenSea;
-    border: 0;
-    color: $white;
-    -webkit-user-select: none;  /* Chrome all / Safari all */
-    -moz-user-select: none;     /* Firefox all */
-    -ms-user-select: none;
-    user-select: none;
-
-    &:hover {
-        color: $white;
-        background-color: $turquoise;
-        @include material-shadow-hover();
-    }
-
-    &::before {
+    button {
         display: block;
-        height: 17px;
-        margin: 0 auto;
-        width: 17px;
+        height: 25px;
+        width: 30px;
+        padding: 0;
+        background-color: $greenSea;
+        color: $white;
+        border: none;
+        border-radius: 0;
+
+        &:hover {
+            color: $white;
+            background-color: $turquoise;
+            @include material-shadow-hover();
+        }
     }
 }
 
@@ -98,42 +101,4 @@
             }
         }
     }
-}
-
-
-.results-shadow {
-    box-shadow: 0 2px 6px rgba($black, 0.3),0 4px 15px -5px rgba($black, 0.0);
-    transition: all 200ms cubic-bezier(0.52,0,0.48,1);
-}
-
-#results {
-    color: $deprecated-color1;
-    -webkit-transform: translateZ(0);
-    transform: translateZ(0);
-    padding: 15px;
-    top: 0;
-    z-index: 9;
-    width: 370px;
-    outline: none;
-    position: absolute;
-    background: $white;
-    margin-top: 11px;
-    margin-left: 16px;
-    transition: opacity 200ms cubic-bezier(0.52,0,0.48,1);
-    opacity: 1;
-}
-
-#results ul li {
-    list-style-image:url('img/globe-icon.png');
-}
-
-#clear {
-    width: 16px;
-    height: 16px;
-    display: inline-block;
-    background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAACXBIWXMAAAsTAAALEwEAmpwYAAAKT2lDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjanVNnVFPpFj333vRCS4iAlEtvUhUIIFJCi4AUkSYqIQkQSoghodkVUcERRUUEG8igiAOOjoCMFVEsDIoK2AfkIaKOg6OIisr74Xuja9a89+bN/rXXPues852zzwfACAyWSDNRNYAMqUIeEeCDx8TG4eQuQIEKJHAAEAizZCFz/SMBAPh+PDwrIsAHvgABeNMLCADATZvAMByH/w/qQplcAYCEAcB0kThLCIAUAEB6jkKmAEBGAYCdmCZTAKAEAGDLY2LjAFAtAGAnf+bTAICd+Jl7AQBblCEVAaCRACATZYhEAGg7AKzPVopFAFgwABRmS8Q5ANgtADBJV2ZIALC3AMDOEAuyAAgMADBRiIUpAAR7AGDIIyN4AISZABRG8lc88SuuEOcqAAB4mbI8uSQ5RYFbCC1xB1dXLh4ozkkXKxQ2YQJhmkAuwnmZGTKBNA/g88wAAKCRFRHgg/P9eM4Ors7ONo62Dl8t6r8G/yJiYuP+5c+rcEAAAOF0ftH+LC+zGoA7BoBt/qIl7gRoXgugdfeLZrIPQLUAoOnaV/Nw+H48PEWhkLnZ2eXk5NhKxEJbYcpXff5nwl/AV/1s+X48/Pf14L7iJIEyXYFHBPjgwsz0TKUcz5IJhGLc5o9H/LcL//wd0yLESWK5WCoU41EScY5EmozzMqUiiUKSKcUl0v9k4t8s+wM+3zUAsGo+AXuRLahdYwP2SycQWHTA4vcAAPK7b8HUKAgDgGiD4c93/+8//UegJQCAZkmScQAAXkQkLlTKsz/HCAAARKCBKrBBG/TBGCzABhzBBdzBC/xgNoRCJMTCQhBCCmSAHHJgKayCQiiGzbAdKmAv1EAdNMBRaIaTcA4uwlW4Dj1wD/phCJ7BKLyBCQRByAgTYSHaiAFiilgjjggXmYX4IcFIBBKLJCDJiBRRIkuRNUgxUopUIFVIHfI9cgI5h1xGupE7yAAygvyGvEcxlIGyUT3UDLVDuag3GoRGogvQZHQxmo8WoJvQcrQaPYw2oefQq2gP2o8+Q8cwwOgYBzPEbDAuxsNCsTgsCZNjy7EirAyrxhqwVqwDu4n1Y8+xdwQSgUXACTYEd0IgYR5BSFhMWE7YSKggHCQ0EdoJNwkDhFHCJyKTqEu0JroR+cQYYjIxh1hILCPWEo8TLxB7iEPENyQSiUMyJ7mQAkmxpFTSEtJG0m5SI+ksqZs0SBojk8naZGuyBzmULCAryIXkneTD5DPkG+Qh8lsKnWJAcaT4U+IoUspqShnlEOU05QZlmDJBVaOaUt2ooVQRNY9aQq2htlKvUYeoEzR1mjnNgxZJS6WtopXTGmgXaPdpr+h0uhHdlR5Ol9BX0svpR+iX6AP0dwwNhhWDx4hnKBmbGAcYZxl3GK+YTKYZ04sZx1QwNzHrmOeZD5lvVVgqtip8FZHKCpVKlSaVGyovVKmqpqreqgtV81XLVI+pXlN9rkZVM1PjqQnUlqtVqp1Q61MbU2epO6iHqmeob1Q/pH5Z/YkGWcNMw09DpFGgsV/jvMYgC2MZs3gsIWsNq4Z1gTXEJrHN2Xx2KruY/R27iz2qqaE5QzNKM1ezUvOUZj8H45hx+Jx0TgnnKKeX836K3hTvKeIpG6Y0TLkxZVxrqpaXllirSKtRq0frvTau7aedpr1Fu1n7gQ5Bx0onXCdHZ4/OBZ3nU9lT3acKpxZNPTr1ri6qa6UbobtEd79up+6Ynr5egJ5Mb6feeb3n+hx9L/1U/W36p/VHDFgGswwkBtsMzhg8xTVxbzwdL8fb8VFDXcNAQ6VhlWGX4YSRudE8o9VGjUYPjGnGXOMk423GbcajJgYmISZLTepN7ppSTbmmKaY7TDtMx83MzaLN1pk1mz0x1zLnm+eb15vft2BaeFostqi2uGVJsuRaplnutrxuhVo5WaVYVVpds0atna0l1rutu6cRp7lOk06rntZnw7Dxtsm2qbcZsOXYBtuutm22fWFnYhdnt8Wuw+6TvZN9un2N/T0HDYfZDqsdWh1+c7RyFDpWOt6azpzuP33F9JbpL2dYzxDP2DPjthPLKcRpnVOb00dnF2e5c4PziIuJS4LLLpc+Lpsbxt3IveRKdPVxXeF60vWdm7Obwu2o26/uNu5p7ofcn8w0nymeWTNz0MPIQ+BR5dE/C5+VMGvfrH5PQ0+BZ7XnIy9jL5FXrdewt6V3qvdh7xc+9j5yn+M+4zw33jLeWV/MN8C3yLfLT8Nvnl+F30N/I/9k/3r/0QCngCUBZwOJgUGBWwL7+Hp8Ib+OPzrbZfay2e1BjKC5QRVBj4KtguXBrSFoyOyQrSH355jOkc5pDoVQfujW0Adh5mGLw34MJ4WHhVeGP45wiFga0TGXNXfR3ENz30T6RJZE3ptnMU85ry1KNSo+qi5qPNo3ujS6P8YuZlnM1VidWElsSxw5LiquNm5svt/87fOH4p3iC+N7F5gvyF1weaHOwvSFpxapLhIsOpZATIhOOJTwQRAqqBaMJfITdyWOCnnCHcJnIi/RNtGI2ENcKh5O8kgqTXqS7JG8NXkkxTOlLOW5hCepkLxMDUzdmzqeFpp2IG0yPTq9MYOSkZBxQqohTZO2Z+pn5mZ2y6xlhbL+xW6Lty8elQfJa7OQrAVZLQq2QqboVFoo1yoHsmdlV2a/zYnKOZarnivN7cyzytuQN5zvn//tEsIS4ZK2pYZLVy0dWOa9rGo5sjxxedsK4xUFK4ZWBqw8uIq2Km3VT6vtV5eufr0mek1rgV7ByoLBtQFr6wtVCuWFfevc1+1dT1gvWd+1YfqGnRs+FYmKrhTbF5cVf9go3HjlG4dvyr+Z3JS0qavEuWTPZtJm6ebeLZ5bDpaql+aXDm4N2dq0Dd9WtO319kXbL5fNKNu7g7ZDuaO/PLi8ZafJzs07P1SkVPRU+lQ27tLdtWHX+G7R7ht7vPY07NXbW7z3/T7JvttVAVVN1WbVZftJ+7P3P66Jqun4lvttXa1ObXHtxwPSA/0HIw6217nU1R3SPVRSj9Yr60cOxx++/p3vdy0NNg1VjZzG4iNwRHnk6fcJ3/ceDTradox7rOEH0x92HWcdL2pCmvKaRptTmvtbYlu6T8w+0dbq3nr8R9sfD5w0PFl5SvNUyWna6YLTk2fyz4ydlZ19fi753GDborZ752PO32oPb++6EHTh0kX/i+c7vDvOXPK4dPKy2+UTV7hXmq86X23qdOo8/pPTT8e7nLuarrlca7nuer21e2b36RueN87d9L158Rb/1tWeOT3dvfN6b/fF9/XfFt1+cif9zsu72Xcn7q28T7xf9EDtQdlD3YfVP1v+3Njv3H9qwHeg89HcR/cGhYPP/pH1jw9DBY+Zj8uGDYbrnjg+OTniP3L96fynQ89kzyaeF/6i/suuFxYvfvjV69fO0ZjRoZfyl5O/bXyl/erA6xmv28bCxh6+yXgzMV70VvvtwXfcdx3vo98PT+R8IH8o/2j5sfVT0Kf7kxmTk/8EA5jz/GMzLdsAAAAgY0hSTQAAeiUAAICDAAD5/wAAgOkAAHUwAADqYAAAOpgAABdvkl/FRgAAAG1JREFUeNrM1EsKwCAMRdEHbtoNuYK7wHTSQaH5TB6lgrN4JIlRESHHlh0CNnCApWEB647dGXSAmLAHEsDJoDVhWcwLqgI7RJJSqDrQXVBCBVam3EIJVtbtG8iSmqXYlvbbHqRzRDxD+5v/6BoANE6rI5kJCPcAAAAASUVORK5CYII=');
-    background-repeat: no-repeat;
-    position: relative;
-    left: 360px;
-    top: -24px;
 }

--- a/app/styles/_searchbox.scss
+++ b/app/styles/_searchbox.scss
@@ -15,10 +15,24 @@
         @include material-shadow-hover();
     }
 
-}
+    input {
+        vertical-align: middle;
+        background-color: transparent;
+        border: 0;
+        font-size: 14px;
+        font-weight: 300;
+        margin: 0;
+        outline: 0;
+        padding: 0;
+        width: 100%;
+        box-shadow: none;
+        height: 30px;
+        color: $asbestos;
 
-.cards-minimized .searchbox-shadow {
-    box-shadow: 0 2px 6px rgba($black, 0.3),0 4px 15px -5px rgba($black, 0.3);
+        &::-webkit-input-speech-button {
+            opacity: 0.5;
+        }
+    }
 }
 
 .searchboxinput {
@@ -36,21 +50,6 @@
     vertical-align: top;
 }
 
-.searchbox input {
-    vertical-align: middle;
-    background-color: transparent;
-    border: 0;
-    font-size: 14px;
-    font-weight: 300;
-    margin: 0;
-    outline: 0;
-    padding: 0;
-    width: 100%;
-    box-shadow: none;
-    height: 30px;
-    color: $asbestos;
-}
-
 .searchbutton {
     position: relative;
     float: left;
@@ -62,46 +61,45 @@
     -moz-user-select: none;     /* Firefox all */
     -ms-user-select: none;
     user-select: none;
+
     &:hover {
         color: $white;
         background-color: $turquoise;
         @include material-shadow-hover();
     }
+
+    &::before {
+        display: block;
+        height: 17px;
+        margin: 0 auto;
+        width: 17px;
+    }
 }
 
+.search-results {
+    > h3 {
+        background-color: $turquoise;
+        font-size: 14px;
+        padding: 10px;
+        color: $white;
+        margin: 0;
+    }
+    > ul {
+        padding: 0;
+        margin: 0;
 
-.searchbutton::before {
-    display: block;
-    height: 17px;
-    margin: 0 auto;
-    width: 17px;
+        > li {
+            &:hover {
+                background-color: $clouds;
+            }
+
+            &:last {
+                margin-bottom: 5px;
+            }
+        }
+    }
 }
 
-.searchbox input::-webkit-input-speech-button {
-    opacity: 0.5;
-}
-
-
-.search-results > ul {
-    padding: 0;
-    margin: 0;
-}
-
-.search-results > ul > li:hover {
-    background-color: $clouds;
-}
-
-.search-results > ul > li:last {
-    margin-bottom: 5px;
-}
-
-.search-results > h3 {
-    background-color: $turquoise;
-    font-size: 14px;
-    padding: 10px;
-    color: $white;
-    margin: 0;
-}
 
 .results-shadow {
     box-shadow: 0 2px 6px rgba($black, 0.3),0 4px 15px -5px rgba($black, 0.0);

--- a/app/styles/_searchbox.scss
+++ b/app/styles/_searchbox.scss
@@ -1,0 +1,141 @@
+.searchbox {
+    background: $white;
+    background: rgba($white, 0.95);
+    border: 1px solid transparent;
+    border-right: 0;
+    border-radius: 2px 0 0 2px;
+    box-sizing: border-box;
+    height: 32px;
+    outline: none;
+    padding: 0 11px 0 13px;
+    width: 462px; // width plus zoom buttons
+    @include material-shadow();
+
+    &:hover {
+        @include material-shadow-hover();
+    }
+
+}
+
+.cards-minimized .searchbox-shadow {
+    box-shadow: 0 2px 6px rgba($black, 0.3),0 4px 15px -5px rgba($black, 0.3);
+}
+
+.searchboxinput {
+    width: 375px;
+    padding: 0px;
+}
+
+.search-button-collection {
+    height: 32px;
+    left: 400px;
+    width: 62px;
+    position: absolute;
+    text-align: center;
+    top: 0;
+    vertical-align: top;
+}
+
+.searchbox input {
+    vertical-align: middle;
+    background-color: transparent;
+    border: 0;
+    font-size: 14px;
+    font-weight: 300;
+    margin: 0;
+    outline: 0;
+    padding: 0;
+    width: 100%;
+    box-shadow: none;
+    height: 30px;
+    color: $asbestos;
+}
+
+.searchbutton {
+    position: relative;
+    float: left;
+    padding: 6px 10px;
+    background-color: $greenSea;
+    border: 0;
+    color: $white;
+    -webkit-user-select: none;  /* Chrome all / Safari all */
+    -moz-user-select: none;     /* Firefox all */
+    -ms-user-select: none;
+    user-select: none;
+    &:hover {
+        color: $white;
+        background-color: $turquoise;
+        @include material-shadow-hover();
+    }
+}
+
+
+.searchbutton::before {
+    display: block;
+    height: 17px;
+    margin: 0 auto;
+    width: 17px;
+}
+
+.searchbox input::-webkit-input-speech-button {
+    opacity: 0.5;
+}
+
+
+.search-results > ul {
+    padding: 0;
+    margin: 0;
+}
+
+.search-results > ul > li:hover {
+    background-color: $clouds;
+}
+
+.search-results > ul > li:last {
+    margin-bottom: 5px;
+}
+
+.search-results > h3 {
+    background-color: $turquoise;
+    font-size: 14px;
+    padding: 10px;
+    color: $white;
+    margin: 0;
+}
+
+.results-shadow {
+    box-shadow: 0 2px 6px rgba($black, 0.3),0 4px 15px -5px rgba($black, 0.0);
+    transition: all 200ms cubic-bezier(0.52,0,0.48,1);
+}
+
+#results {
+    color: $deprecated-color1;
+    -webkit-transform: translateZ(0);
+    transform: translateZ(0);
+    padding: 15px;
+    top: 0;
+    z-index: 9;
+    width: 370px;
+    outline: none;
+    position: absolute;
+    background: $white;
+    margin-top: 11px;
+    margin-left: 16px;
+    transition: opacity 200ms cubic-bezier(0.52,0,0.48,1);
+    opacity: 1;
+}
+
+#results ul li {
+    list-style-image:url('img/globe-icon.png');
+}
+
+#clear {
+    width: 16px;
+    height: 16px;
+    display: inline-block;
+    background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAACXBIWXMAAAsTAAALEwEAmpwYAAAKT2lDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjanVNnVFPpFj333vRCS4iAlEtvUhUIIFJCi4AUkSYqIQkQSoghodkVUcERRUUEG8igiAOOjoCMFVEsDIoK2AfkIaKOg6OIisr74Xuja9a89+bN/rXXPues852zzwfACAyWSDNRNYAMqUIeEeCDx8TG4eQuQIEKJHAAEAizZCFz/SMBAPh+PDwrIsAHvgABeNMLCADATZvAMByH/w/qQplcAYCEAcB0kThLCIAUAEB6jkKmAEBGAYCdmCZTAKAEAGDLY2LjAFAtAGAnf+bTAICd+Jl7AQBblCEVAaCRACATZYhEAGg7AKzPVopFAFgwABRmS8Q5ANgtADBJV2ZIALC3AMDOEAuyAAgMADBRiIUpAAR7AGDIIyN4AISZABRG8lc88SuuEOcqAAB4mbI8uSQ5RYFbCC1xB1dXLh4ozkkXKxQ2YQJhmkAuwnmZGTKBNA/g88wAAKCRFRHgg/P9eM4Ors7ONo62Dl8t6r8G/yJiYuP+5c+rcEAAAOF0ftH+LC+zGoA7BoBt/qIl7gRoXgugdfeLZrIPQLUAoOnaV/Nw+H48PEWhkLnZ2eXk5NhKxEJbYcpXff5nwl/AV/1s+X48/Pf14L7iJIEyXYFHBPjgwsz0TKUcz5IJhGLc5o9H/LcL//wd0yLESWK5WCoU41EScY5EmozzMqUiiUKSKcUl0v9k4t8s+wM+3zUAsGo+AXuRLahdYwP2SycQWHTA4vcAAPK7b8HUKAgDgGiD4c93/+8//UegJQCAZkmScQAAXkQkLlTKsz/HCAAARKCBKrBBG/TBGCzABhzBBdzBC/xgNoRCJMTCQhBCCmSAHHJgKayCQiiGzbAdKmAv1EAdNMBRaIaTcA4uwlW4Dj1wD/phCJ7BKLyBCQRByAgTYSHaiAFiilgjjggXmYX4IcFIBBKLJCDJiBRRIkuRNUgxUopUIFVIHfI9cgI5h1xGupE7yAAygvyGvEcxlIGyUT3UDLVDuag3GoRGogvQZHQxmo8WoJvQcrQaPYw2oefQq2gP2o8+Q8cwwOgYBzPEbDAuxsNCsTgsCZNjy7EirAyrxhqwVqwDu4n1Y8+xdwQSgUXACTYEd0IgYR5BSFhMWE7YSKggHCQ0EdoJNwkDhFHCJyKTqEu0JroR+cQYYjIxh1hILCPWEo8TLxB7iEPENyQSiUMyJ7mQAkmxpFTSEtJG0m5SI+ksqZs0SBojk8naZGuyBzmULCAryIXkneTD5DPkG+Qh8lsKnWJAcaT4U+IoUspqShnlEOU05QZlmDJBVaOaUt2ooVQRNY9aQq2htlKvUYeoEzR1mjnNgxZJS6WtopXTGmgXaPdpr+h0uhHdlR5Ol9BX0svpR+iX6AP0dwwNhhWDx4hnKBmbGAcYZxl3GK+YTKYZ04sZx1QwNzHrmOeZD5lvVVgqtip8FZHKCpVKlSaVGyovVKmqpqreqgtV81XLVI+pXlN9rkZVM1PjqQnUlqtVqp1Q61MbU2epO6iHqmeob1Q/pH5Z/YkGWcNMw09DpFGgsV/jvMYgC2MZs3gsIWsNq4Z1gTXEJrHN2Xx2KruY/R27iz2qqaE5QzNKM1ezUvOUZj8H45hx+Jx0TgnnKKeX836K3hTvKeIpG6Y0TLkxZVxrqpaXllirSKtRq0frvTau7aedpr1Fu1n7gQ5Bx0onXCdHZ4/OBZ3nU9lT3acKpxZNPTr1ri6qa6UbobtEd79up+6Ynr5egJ5Mb6feeb3n+hx9L/1U/W36p/VHDFgGswwkBtsMzhg8xTVxbzwdL8fb8VFDXcNAQ6VhlWGX4YSRudE8o9VGjUYPjGnGXOMk423GbcajJgYmISZLTepN7ppSTbmmKaY7TDtMx83MzaLN1pk1mz0x1zLnm+eb15vft2BaeFostqi2uGVJsuRaplnutrxuhVo5WaVYVVpds0atna0l1rutu6cRp7lOk06rntZnw7Dxtsm2qbcZsOXYBtuutm22fWFnYhdnt8Wuw+6TvZN9un2N/T0HDYfZDqsdWh1+c7RyFDpWOt6azpzuP33F9JbpL2dYzxDP2DPjthPLKcRpnVOb00dnF2e5c4PziIuJS4LLLpc+Lpsbxt3IveRKdPVxXeF60vWdm7Obwu2o26/uNu5p7ofcn8w0nymeWTNz0MPIQ+BR5dE/C5+VMGvfrH5PQ0+BZ7XnIy9jL5FXrdewt6V3qvdh7xc+9j5yn+M+4zw33jLeWV/MN8C3yLfLT8Nvnl+F30N/I/9k/3r/0QCngCUBZwOJgUGBWwL7+Hp8Ib+OPzrbZfay2e1BjKC5QRVBj4KtguXBrSFoyOyQrSH355jOkc5pDoVQfujW0Adh5mGLw34MJ4WHhVeGP45wiFga0TGXNXfR3ENz30T6RJZE3ptnMU85ry1KNSo+qi5qPNo3ujS6P8YuZlnM1VidWElsSxw5LiquNm5svt/87fOH4p3iC+N7F5gvyF1weaHOwvSFpxapLhIsOpZATIhOOJTwQRAqqBaMJfITdyWOCnnCHcJnIi/RNtGI2ENcKh5O8kgqTXqS7JG8NXkkxTOlLOW5hCepkLxMDUzdmzqeFpp2IG0yPTq9MYOSkZBxQqohTZO2Z+pn5mZ2y6xlhbL+xW6Lty8elQfJa7OQrAVZLQq2QqboVFoo1yoHsmdlV2a/zYnKOZarnivN7cyzytuQN5zvn//tEsIS4ZK2pYZLVy0dWOa9rGo5sjxxedsK4xUFK4ZWBqw8uIq2Km3VT6vtV5eufr0mek1rgV7ByoLBtQFr6wtVCuWFfevc1+1dT1gvWd+1YfqGnRs+FYmKrhTbF5cVf9go3HjlG4dvyr+Z3JS0qavEuWTPZtJm6ebeLZ5bDpaql+aXDm4N2dq0Dd9WtO319kXbL5fNKNu7g7ZDuaO/PLi8ZafJzs07P1SkVPRU+lQ27tLdtWHX+G7R7ht7vPY07NXbW7z3/T7JvttVAVVN1WbVZftJ+7P3P66Jqun4lvttXa1ObXHtxwPSA/0HIw6217nU1R3SPVRSj9Yr60cOxx++/p3vdy0NNg1VjZzG4iNwRHnk6fcJ3/ceDTradox7rOEH0x92HWcdL2pCmvKaRptTmvtbYlu6T8w+0dbq3nr8R9sfD5w0PFl5SvNUyWna6YLTk2fyz4ydlZ19fi753GDborZ752PO32oPb++6EHTh0kX/i+c7vDvOXPK4dPKy2+UTV7hXmq86X23qdOo8/pPTT8e7nLuarrlca7nuer21e2b36RueN87d9L158Rb/1tWeOT3dvfN6b/fF9/XfFt1+cif9zsu72Xcn7q28T7xf9EDtQdlD3YfVP1v+3Njv3H9qwHeg89HcR/cGhYPP/pH1jw9DBY+Zj8uGDYbrnjg+OTniP3L96fynQ89kzyaeF/6i/suuFxYvfvjV69fO0ZjRoZfyl5O/bXyl/erA6xmv28bCxh6+yXgzMV70VvvtwXfcdx3vo98PT+R8IH8o/2j5sfVT0Kf7kxmTk/8EA5jz/GMzLdsAAAAgY0hSTQAAeiUAAICDAAD5/wAAgOkAAHUwAADqYAAAOpgAABdvkl/FRgAAAG1JREFUeNrM1EsKwCAMRdEHbtoNuYK7wHTSQaH5TB6lgrN4JIlRESHHlh0CNnCApWEB647dGXSAmLAHEsDJoDVhWcwLqgI7RJJSqDrQXVBCBVam3EIJVtbtG8iSmqXYlvbbHqRzRDxD+5v/6BoANE6rI5kJCPcAAAAASUVORK5CYII=');
+    background-repeat: no-repeat;
+    position: relative;
+    left: 360px;
+    top: -24px;
+}

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -126,6 +126,7 @@ $navbarandtimeline: 50px + 82px;
 
 @import 'layout';
 @import 'omnibox';
+@import 'searchbox';
 @import 'graph';
 @import 'navbar';
 @import 'layer-chooser';


### PR DESCRIPTION
The commits might be out of order because of rebasing.

Notes from the commits:

--
> Don't show 'clear all' button until someone has actually performed a search query.

--
> If the omnibox is resized, the entire searchbox will adapt. No need to change any widths.
> Unfortunately this means that the HTML is in completely the wrong order.
> Ideally we would've had: search input box, the clear button, zoom buttons.
> Also acceptable would've been: zoom buttons, search input box, clear button.
> However reality is: zoom buttons, clear button, search input box.
> Gijs and I think this is acceptable considering it is a JS app.

--
> Improve key accessibility and tab indexability.
> Keys:
> 
> * [modifier key] + s: search;
> * [modifier key] + q: close search results;
> * [modifier key] + +: zoom in on the map;
> * [modifier key] + -: zoom out on the map;
> * [modifier key] + d: switch to dashboard;
> * [modifier key] + m: switch to map.
> 
> Tab-index order:
> 
> 1. Search;
> 2. Tab through Search Results;
> 3. Close search results;
> 4. Zoom.
> 
> After that it tabs to something invisible and then the user menu.