### PR TITLE
Ernst dashboard drag and drop

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Changelog of lizard-nxt client
 Unreleased (2.6.2) (XXXX-XX-XX)
 -------------------------------
 
+- Enable toggling timeseries and temporal raster data off in db.
+
+- Add subtle grid in db.
+
+- Improve allignment of graphs in db.
+
 - Fix landuse, kind of.
 
 - Fix no rain export.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog of lizard-nxt client
 Unreleased (2.6.2) (XXXX-XX-XX)
 -------------------------------
 
+- Add default color and order to timeseries.
+
 - Enable toggling timeseries and temporal raster data off in db.
 
 - Add subtle grid in db.

--- a/app/components/dashboard/dashboard-directive.js
+++ b/app/components/dashboard/dashboard-directive.js
@@ -33,7 +33,7 @@ angular.module('dashboard')
           graph.dimensions = DashboardService.getDimensions(
             element,
             scope.dashboard.graphs.length,
-            graph.type === 'distance'
+            graph.type === 'distance' // give space for axis.
           );
         });
 

--- a/app/components/dashboard/dashboard-service.js
+++ b/app/components/dashboard/dashboard-service.js
@@ -6,7 +6,7 @@ angular.module('dashboard')
   this.GRAPH_PADDING = 13; // Padding around the graph svg. Not to be confused
                           // with the padding inside the svg which is used for
                           // axis and labels.
-  var ROW_BOTTOM_MARGIN = 10; // Pixels between graph rows.
+  var ROW_BOTTOM_MARGIN = 20; // Pixels between graph rows.
 
 
   /**
@@ -61,15 +61,17 @@ angular.module('dashboard')
    * @return {object}          dimension object per graph.
    */
   this.getDimensions = function (element, nGraphs, showXAxis) {
-
+    var AXIS_LABEL_SPACE = 60;
+    var AXIS_DEFAULT_SPACE = 15;
+    var PAD = 10;
     return {
       width: element.width() - this.GRAPH_PADDING,
       height: getGraphHeight(element, nGraphs),
       padding: {
-        top: 10,
-        right: 10,
-        bottom: showXAxis ? 40 : 15,
-        left: 10
+        top: PAD,
+        right: PAD,
+        bottom: showXAxis ? AXIS_LABEL_SPACE : AXIS_DEFAULT_SPACE,
+        left: AXIS_LABEL_SPACE
       }
     };
   };
@@ -82,7 +84,7 @@ angular.module('dashboard')
    */
   var addPropertyData = function (graphs, properties) {
     _.forEach(properties, function (property, slug) {
-      if (property.data.length > 1) {
+      if (property.active && property.data.length > 1) {
         var item = {
           data: property.data,
           keys: {x: 0, y: {y0: 1, y1: 1}},

--- a/app/components/dashboard/dashboard-service.js
+++ b/app/components/dashboard/dashboard-service.js
@@ -34,11 +34,11 @@ angular.module('dashboard')
     var graphs = [];
 
     if (timeseries.length) {
-      var content = [];
       timeseries.forEach(function (ts) {
+        var content = [];
         content.push(ts);
+        graphs.push({ 'type': 'temporalLine', 'content': content });
       });
-      graphs.push({ 'type': 'temporalLine', 'content': content });
     }
 
     assets.forEach(function (asset) {

--- a/app/components/dashboard/dashboard-service.js
+++ b/app/components/dashboard/dashboard-service.js
@@ -87,10 +87,11 @@ angular.module('dashboard')
       if (property.active && property.data.length > 1) {
         var item = {
           data: property.data,
-          keys: {x: 0, y: {y0: 1, y1: 1}},
+          keys: {x: 0, y: 1},
           labels: {x: 'm', y: property.unit }
         };
-        graphs.push({ type: 'distance', content: [item] });
+        var type = slug === 'rain' ? 'rain' : 'distance';
+        graphs.push({ type: type, content: [item] });
       }
     });
     return graphs;

--- a/app/components/dashboard/dashboard.html
+++ b/app/components/dashboard/dashboard.html
@@ -31,4 +31,20 @@
 
     </div>
 
+    <div
+      ng-if="item.type === 'rain'"
+      class="row"
+      ng-repeat="item in dashboard.graphs">
+
+      <div class="dashboard-inner">
+        <graph
+          bar-chart
+          content="item.content"
+          temporal="dashboard.state.temporal"
+          dimensions="item.dimensions">
+         <graph/>
+      </div>
+
+    </div>
+
 </div>

--- a/app/components/data-menu/services/data-service.js
+++ b/app/components/data-menu/services/data-service.js
@@ -498,7 +498,11 @@ angular.module('data-menu')
         }
 
         angular.forEach(this.layerGroups, function (layerGroup) {
-          if (layerGroup.slug === instance.utfLayerGroup.slug) { return; }
+          // UTF has a special status and is not queried in this loop. Only get
+          // data for non temporal or point. Too many dimensions.
+          if (layerGroup.slug === instance.utfLayerGroup.slug
+            || (layerGroup.temporal && geo.geometry.type !== 'Point')) {
+            return; }
 
           promises.push(
             layerGroup.getData('DataService', options).then(null, null, function (response) {

--- a/app/components/data-menu/services/data-service.js
+++ b/app/components/data-menu/services/data-service.js
@@ -21,7 +21,6 @@ angular.module('data-menu')
   .service('DataService', [
     '$q',
     'AssetService',
-    'TimeseriesService',
     'dataLayers',
     'DataLayerGroup',
     'State',
@@ -29,7 +28,6 @@ angular.module('data-menu')
     function (
       $q,
       AssetService,
-      TimeseriesService,
       dataLayers,
       DataLayerGroup,
       State

--- a/app/components/graph/chart-container-service.js
+++ b/app/components/graph/chart-container-service.js
@@ -20,6 +20,9 @@ angular.module('lizard-nxt')
    * For now this is a way to keep track of the scales, domains and xy's of the graph
    */
   function ChartContainer (content, graph, temporal) {
+
+    var DEFAULT_GREEN = '#16a085';
+
     this._x = null;
 
     this._graph = graph;
@@ -31,6 +34,8 @@ angular.module('lizard-nxt')
     };
     this.keys = content.keys || defaultKeys;
     this.labels = content.labels || {x: '', y:''};
+
+    this.color = content.color || DEFAULT_GREEN;
 
     var options = {
       x: {

--- a/app/components/graph/graph-service.js
+++ b/app/components/graph/graph-service.js
@@ -112,23 +112,6 @@ angular.module('lizard-nxt')
     angular.forEach(content, function (item, index) {
       var chartContainer;
 
-      var colorIndex = 0; // unless proven otherwise
-      if (content.constructor === Object) {
-        colorIndex = Object.keys(content).indexOf(index);
-      } else {
-        colorIndex = index;
-      }
-
-      var colors = [
-        '#16a085',
-        '#3498db',
-        '#c0392b',
-        '#2980b9',
-        '#1abc9c',
-        '#7f8c8d',
-        '#e74c3c',
-      ];
-
       // only update things, don't instantiate new ones
       if (graph._containers[index]) {
         if (graph._containers[index].constructor === ChartContainer) {
@@ -140,8 +123,6 @@ angular.module('lizard-nxt')
         graph._containers[index] = new ChartContainer(item, graph, temporal);
         chartContainer = graph._containers[index];
       }
-
-      chartContainer.color = colors[colorIndex];
 
       var data = chartContainer.data,
           keys = chartContainer.keys,

--- a/app/components/graph/graph-service.js
+++ b/app/components/graph/graph-service.js
@@ -398,11 +398,20 @@ angular.module('lizard-nxt')
           }
         };
       }
+
+      var width = this._getWidth(this.dimensions);
+
       var xy = {x: {}, y: {}};
 
       angular.forEach(xy, function (value, key) {
         var y = key === 'y';
-        xy[key] = this._createD3Objects(data, keys[key], options[key], y);
+        options[key].drawGrid = width > MIN_WIDTH_INTERACTIVE_GRAPHS && y;
+        xy[key] = this._createD3Objects(
+          data,
+          keys[key],
+          options[key],
+          y
+        );
         drawAxes(this._svg, xy[key].axis, this.dimensions, y);
         drawLabel(this._svg, this.dimensions, labels[key], y);
       }, this);
@@ -504,7 +513,7 @@ angular.module('lizard-nxt')
           origin[key] = value.maxMin.min;
         }
         value.scale.domain([origin[key], value.maxMin.max]);
-        value.axis = Graph.prototype._makeAxis(value.scale, {orientation: orientation[key]});
+        // value.axis = Graph.prototype._makeAxis(value.scale, {orientation: orientation[key]});
         drawAxes(svg, value.axis, dimensions, key === 'y' ? true : false, Graph.prototype.transTime);
       }
     });

--- a/app/components/map/map-directives.js
+++ b/app/components/map/map-directives.js
@@ -13,14 +13,12 @@
  */
 angular.module('map')
   .directive('map', [
-  '$controller',
   'MapService',
   'DataService',
   'ClickFeedbackService',
   'UtilService',
   'State',
   function (
-    $controller,
     MapService,
     DataService,
     ClickFeedbackService,

--- a/app/components/map/services/non-tiled-wms-layer-service.js
+++ b/app/components/map/services/non-tiled-wms-layer-service.js
@@ -166,7 +166,8 @@ angular.module('map')
               var defer = $q.defer();
 
               // Resolve and return when nothing changed.
-              if (timeState.at === this.timeState.at
+              if (this.timeState &&
+                timeState.at === this.timeState.at
                 && timeState.aggWindow === this.timeState.aggWindow
                 && timeState.playing === this.timeState.playing) {
                 defer.resolve();

--- a/app/components/omnibox/directives/db-asset-card-directive.js
+++ b/app/components/omnibox/directives/db-asset-card-directive.js
@@ -16,6 +16,7 @@ angular.module('omnibox')
           var selectedTS = [];
           scope.asset.timeseries.forEach(function (ts) {
             selectedTS.push(ts.uuid);
+            ts.active = true;
             scope.noTimeseries = false;
           });
 
@@ -44,6 +45,25 @@ angular.module('omnibox')
           }
         );
       });
+
+      scope.toggleTimeseries = function (timeseries) {
+        var add = true;
+
+        State.selected.timeseries = _.filter(State.selected.timeseries, function (ts) {
+          var keep = ts !== timeseries.uuid;
+          if (!keep) {
+            add = false;
+            timeseries.active = false;
+          }
+          return keep;
+        });
+
+        if (add) {
+          timeseries.active = true;
+          State.selected.timeseries = _.union(State.selected.timeseries, [timeseries.uuid]);
+        }
+
+      };
 
     },
     restrict: 'E',

--- a/app/components/omnibox/directives/db-geometry-card-directive.js
+++ b/app/components/omnibox/directives/db-geometry-card-directive.js
@@ -1,7 +1,7 @@
 
 angular.module('omnibox')
-.directive('dbGeometryCards', [ 'State',
-  function (State) {
+.directive('dbGeometryCards', [ 'State', 'DataService',
+  function (State, DataService) {
     return {
       link: function (scope) {
 
@@ -13,12 +13,26 @@ angular.module('omnibox')
          */
         scope.$watch('geom.properties', function (n, o) {
 
+          _.forEach(scope.geom.properties, function (property) {
+            if (property.active === undefined) {
+              property.active = true;
+            }
+          });
+
           scope.noRasterData = !_.some(scope.geom.properties, function (property) {
             return property.data && property.data.length > 1;
           });
 
           scope.noData = scope.noRasterData && scope.geom.entity_name === undefined;
         }, true);
+
+
+        scope.toggleProperty = function (property) {
+          property.active = !property.active;
+          if (DataService.onGeometriesChange) {
+            DataService.onGeometriesChange();
+          }
+        };
 
       },
       restrict: 'E',

--- a/app/components/omnibox/templates/db-asset-card.html
+++ b/app/components/omnibox/templates/db-asset-card.html
@@ -13,7 +13,7 @@
         <i class="fa fa-clock-o"></i>
         <span ng-class="{'text-primary bg-warning': s.active}"><% s.location.name %>, <% s.parameter_referenced_unit.parameter_short_display_name %></span>
       </div>
-      <div class="circle pull-right"></div>
+      <div class="circle pull-right" ng-style="{'background-color': s.color}"></div>
     </div>
 
   </div>

--- a/app/components/omnibox/templates/db-asset-card.html
+++ b/app/components/omnibox/templates/db-asset-card.html
@@ -9,9 +9,9 @@
     <em ng-if="noTimeseries" translate>No timeseries available for this asset</em>
 
     <div ng-repeat="s in asset.timeseries">
-      <div draggable="true" class="card-content-list">
+      <div ng-click="toggleTimeseries(s)" class="card-content-list clickable">
         <i class="fa fa-clock-o"></i>
-        <span><% s.location.name %>, <% s.parameter_referenced_unit.parameter_short_display_name %></span>
+        <span ng-class="{'text-primary bg-warning': s.active}"><% s.location.name %>, <% s.parameter_referenced_unit.parameter_short_display_name %></span>
       </div>
       <div class="circle pull-right"></div>
     </div>

--- a/app/components/omnibox/templates/db-geometry-cards.html
+++ b/app/components/omnibox/templates/db-geometry-cards.html
@@ -7,9 +7,9 @@
     <em ng-if="noData" translate>No data available for this geometry</em>
 
 		<div ng-if="prop.data.length > 1" ng-repeat="prop in geom.properties">
-		  <div class="card-content-list">
+		  <div ng-click="toggleProperty(prop)" class="card-content-list clickable">
 		    <i class="fa fa-line-chart"></i>
-		    <span><% prop.quantity %>, (<% prop.unit %>)</span>
+		    <span ng-class="{'text-primary bg-warning': prop.active}"><% prop.quantity %>, (<% prop.unit %>)</span>
 		  </div>
 		  <div class="circle pull-right"></div>
 		</div>

--- a/app/components/state/state-service.js
+++ b/app/components/state/state-service.js
@@ -30,7 +30,7 @@ angular.module('global-state')
 
     // Context. State.context returns 'map' or 'db', it can only be set with
     // either one of those values.
-    var _context = 'map'; // The default
+    var _context = ''; // Set on init from url or defaults to map.
     var CONTEXT_VALUES = ['map', 'dashboard', 'scenarios'];
     Object.defineProperty(state, 'context', {
       get: function () { return _context; },

--- a/app/components/url/url-controller.js
+++ b/app/components/url/url-controller.js
@@ -230,7 +230,7 @@ angular.module('lizard-nxt')
       if (n === old) { return true; }
       state.context.update = false;
       LocationGetterSetter.setUrlValue(
-        state.context.part, state.context.index, $scope.context
+        state.context.part, state.context.index, State.context
       );
     });
 
@@ -261,17 +261,12 @@ angular.module('lizard-nxt')
       );
 
       if (context) {
-        // Set context after digest loop because we need to enter on 'map'
-        $timeout(
-          function () {
-            $scope.transitionToContext(context);
-          },
-          0, // no delay, fire when digest ends
-          true // trigger new digest loop
-        );
+        $scope.transitionToContext(context);
       } else {
         LocationGetterSetter.setUrlValue(state.context.part, state.context.index, state.context.value);
+        $scope.transitionToContext(state.context.value);
       }
+      $rootScope.context = State.context;
 
       if (boxType) {
         State.box.type = boxType;

--- a/app/index.html
+++ b/app/index.html
@@ -31,7 +31,7 @@
 
   </head>
 
-  <body>
+  <body ng-controller="UrlController">
 
     <div ng-if="context === 'map' || context === 'scenarios'">
       <map></map>

--- a/app/lib/nxt-d3-service.js
+++ b/app/lib/nxt-d3-service.js
@@ -48,7 +48,7 @@ angular.module('lizard-nxt')
      * @description        The duration of transitions in ms. Use(d)
      *                     throughout the graphs and timeline.
      */
-    transTime: 120,
+    transTime: 300,
 
     /**
      * @attribute
@@ -307,8 +307,8 @@ angular.module('lizard-nxt')
       // Make an axis for d3 based on a scale
       var decimalCount,
           axis = d3.svg.axis()
-            .scale(scale)
-            .orient(options.orientation);
+          .scale(scale)
+          .orient(options.orientation);
       if (options.ticks) {
         axis.ticks(options.ticks);
       } else {
@@ -344,6 +344,13 @@ angular.module('lizard-nxt')
           }
         }
       }
+
+      if (options.drawGrid) {
+        var gridLength = this._getWidth(this.dimensions);
+        axis
+          .tickSize(-gridLength);
+      }
+
       return axis;
     },
 

--- a/app/lib/util-service.js
+++ b/app/lib/util-service.js
@@ -41,6 +41,23 @@ angular.module('lizard-nxt')
     return roundedTimestamp;
   };
 
+  // List of graph colors used to color timeseries
+  this.GRAPH_COLORS = [
+    '#1abc9c', // turquoise
+    '#3498db', // peterRiver
+    '#f1c40f', // sunflower
+    '#9b59b6', // amethyst
+    '#2ecc71', // emerald
+    '#2980b9', // belizeHole
+    '#e67e22', // carrot
+    '#8e44ad', // wisteria
+    '#16a085', // greenSea
+    '#34495e', // wetAsphalt
+    '#27ae60', // nephritis
+    '#f39c12', // orange
+    '#2c3e50', // midnightBlue
+    '#d35400' // pumpkin
+  ];
 
   /**
    * Returns true for <protocol>:<domain>.

--- a/app/lizard-nxt-master-controller.js
+++ b/app/lizard-nxt-master-controller.js
@@ -16,7 +16,6 @@ angular.module('lizard-nxt')
   .controller('MasterCtrl',
 
   ['$scope',
-   '$controller',
    '$timeout',
    'CabinetService',
    'UtilService',
@@ -27,7 +26,6 @@ angular.module('lizard-nxt')
    'MapService',
 
   function ($scope,
-            $controller,
             $timeout,
             CabinetService,
             UtilService,
@@ -55,6 +53,7 @@ angular.module('lizard-nxt')
    */
   $scope.transitionToContext = function (context) {
     if (context !== State.context) {
+      State.context = context;
       var overlay = angular.element('#context-transition-overlay')[0];
       overlay.style.transition = null;
       overlay.style.minHeight = window.innerHeight + 'px';
@@ -63,7 +62,6 @@ angular.module('lizard-nxt')
         overlay.style.opacity = 1;
       }, 10);
       $timeout(function () {
-        State.context = context;
         $scope.context = State.context;
         overlay.style.opacity = 0;
       }, 300);
@@ -73,9 +71,6 @@ angular.module('lizard-nxt')
       }, 600, true);
     }
   };
-
-  // initialise context.
-  $scope.context = State.context;
 
   $scope.toggleDashboard = function () {
     $scope.transitionToContext(($scope.context === 'map') ? 'dashboard' : 'map');
@@ -92,9 +87,6 @@ angular.module('lizard-nxt')
   // catch window.load event
   window.addEventListener("load", function () {
     window.loaded = true;
-    $scope.$apply(function () {
-      $controller('UrlController', {$scope: $scope});
-    });
   });
 
 

--- a/app/styles/_dashboard.scss
+++ b/app/styles/_dashboard.scss
@@ -16,6 +16,7 @@
 .dashboard-wrapper .row {
   min-height: 50px;
   margin: 3px;
+  margin-bottom: 10px;
   padding: 3px;
   @include material-shadow();
 

--- a/app/styles/_graph.scss
+++ b/app/styles/_graph.scss
@@ -20,8 +20,14 @@
     stroke-width: 2;
 }
 
-.axis line {
+.y-axis {
+  g line {
+    stroke-width: 1px;
+    stroke-dasharray: 1;
+  }
+  path {
     display: none;
+  }
 }
 
 .line {

--- a/test/spec/url-tests.js
+++ b/test/spec/url-tests.js
@@ -242,7 +242,10 @@ describe('Testing hash controller', function () {
     // Mock the box
     $scope.box = {type: 'area'};
 
+    $scope.transitionToContext = function () {};
+
     createController = function (scope) {
+
       return $controller('UrlController', {
         '$scope': $scope,
         'LocationGetterSetter': LocationGetterSetter


### PR DESCRIPTION
It does not enable drag and drop.

It fixes some alignment issues in db, adds bars and functionality to toggle data in db and sets color and order of graphs in the correct place. Adhering to order and for users to change color and order still needs to be done.

I thought it would be a quick win to add a grid to dashboard graphs. They are subtle so click full screen:

![image](https://cloud.githubusercontent.com/assets/4438154/12922439/d1eebcd4-cf51-11e5-9d2c-ba7508771183.png)