### PR TITLE
Only close search on X-button fixes #1565

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,9 @@ Changelog of lizard-nxt client
 
 Unreleased (2.9.0) (XXXX-XX-XX)
 -------------------------------
--
+- Fix bug 1565 that close button on search closes all da tings.
+
+- Fix duplicate retrieval of assets (undocumented bug).
 
 
 Release 2.10.2 (2016-3-18)

--- a/app/components/data-menu/services/data-service.js
+++ b/app/components/data-menu/services/data-service.js
@@ -111,6 +111,10 @@ angular.module('data-menu')
           var assetId = asset.entity_name + '$' + asset.id;
           return _assets.indexOf(assetId) !== -1;
         });
+
+        // deduplicate assets
+        instance.assets = _.uniqBy(instance.assets, _.isEqual);
+
         instance.getGeomDataForAssets(instance.oldAssets, instance.assets);
 
         if (instance.onAssetsChange) {

--- a/app/components/omnibox/directives/search-directive.js
+++ b/app/components/omnibox/directives/search-directive.js
@@ -58,7 +58,6 @@ angular.module('omnibox')
      * (5) - Clear the click feedback.
      */
     scope.cleanInput = function () {
-      State.selected.reset();
       scope.query = "";
       scope.omnibox.searchResults = {};
     };

--- a/app/styles/_searchbox.scss
+++ b/app/styles/_searchbox.scss
@@ -91,7 +91,7 @@ $zoombutton-width: 30px;
 
 .search-results {
     > h3 {
-        background-color: $turquoise;
+        background-color: $greenSea;
         font-size: 14px;
         padding: $searchbox-margins;
         color: $white;


### PR DESCRIPTION
* Fix bug 1565 that close button on search closes all da tings.
* Fix duplicate retrieval of assets (undocumented bug).