### PR TITLE
Ernst event bar chart fixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,10 @@ Changelog of lizard-nxt client
 
 Unreleased (2.9.0) (XXXX-XX-XX)
 -------------------------------
--
+
+- Remove events from timeline when in db, since db shows it in a graph.
+
+- Fix events hopping around freely on the timeline when dragging.
 
 
 Release 2.10.2 (2016-3-18)

--- a/app/components/omnibox/templates/db-geometry-cards.html
+++ b/app/components/omnibox/templates/db-geometry-cards.html
@@ -7,7 +7,7 @@
     <em ng-if="noData" translate>No raster data available for this geometry</em>
 
     <div
-      ng-if="slug === 'rain' || geom.geometry.type !== 'Point'"
+      ng-if="slug === 'rain' || geom.geometry.type !== 'Point' || prop.format === 'Vector'"
       ng-repeat="(slug, prop) in geom.properties">
       <div ng-click="toggleProperty(prop)" class="card-content-list clickable">
         <i class="fa fa-line-chart"></i>

--- a/app/components/omnibox/templates/geometry-cards.html
+++ b/app/components/omnibox/templates/geometry-cards.html
@@ -20,9 +20,8 @@
     time-state="timeState">
   </annotations>
 
-
   <defaultpoint
-    ng-if="geom.geometry.type === 'Point' && !geom.properties.rain "
+    ng-if="geom.geometry.type === 'Point' && !geom.properties.rain && slug !== 'annotations'"
     ng-repeat="(slug, content) in geom.properties"
     content="content"
     name="slug"
@@ -30,24 +29,16 @@
   </defaultpoint>
 
   <div
-    ng-if="geom.geometry.type === 'LineString'"
+    ng-if="geom.geometry.type === 'LineString' && (content.scale === 'interval' || content.scale === 'ratio')"
     class="card active card-content"
     ng-repeat="(slug, content) in geom.properties">
-    <graph ng-if="content.scale === 'interval' || content.scale === 'ratio'"
+
+    <graph
       line
       data="content.data"
       ylabel="content.quantity + ' [' + content.unit + ']'"
       xlabel="'Afstand in [m]'">
     </graph>
-    <!--    TODO: get proper response from the server when requesting a line of
-    nominal dat and decomment this line
-    <graph ng-if="l.scale === 'nominal'"
-      horizontal-stack
-      data="l.data"
-      keys="{x: 'data', y: 'label'}"
-      xlabel="'[%]'"
-      dimensions="{height: 80, padding: {left: 0, right: 0, top: 5, bottom: 50}}">
-    </graph> -->
 
     <div class="card-tools">
        <a
@@ -72,7 +63,7 @@
 
     <div class="card-content">
 
-      <div ng-if="content.format === 'Vector'">
+      <div ng-if="content.format === 'Vector' && slug !== 'annotations'">
         <span class="card-title">
           <span><i class="fa fa-circle" ng-style="{'color': content.color }"></i></span>
           <span><% content.data.length %></span>

--- a/app/components/timeline/timeline-directives.js
+++ b/app/components/timeline/timeline-directives.js
@@ -179,22 +179,24 @@ angular.module('lizard-nxt')
                             rasterStore: {layers: []},
                             rain: undefined};
 
-      angular.forEach(layerGroups, function (layergroup) {
-        if (layergroup.isActive()) {
-          angular.forEach(layergroup._dataLayers, function (layer) {
-            if (layer.format === "Vector") {
-              timelineLayers.events.layers.push(layer);
-              timelineLayers.events.slugs.push(layer.slug);
-            } else if (layer.format === "Store" && State.context !== 'dashboard') {
-              if (layer.slug !== "rain") {
-                timelineLayers.rasterStore.layers.push(layer);
-              } else if (layer.slug === "rain") {
-                timelineLayers.rain = layer;
-              }
-           }
-          });
-        }
-      });
+      if (State.context !== 'dashboard') {
+        angular.forEach(layerGroups, function (layergroup) {
+          if (layergroup.isActive()) {
+            angular.forEach(layergroup._dataLayers, function (layer) {
+              if (layer.format === "Vector") {
+                timelineLayers.events.layers.push(layer);
+                timelineLayers.events.slugs.push(layer.slug);
+              } else if (layer.format === "Store" && State.context !== 'dashboard') {
+                if (layer.slug !== "rain") {
+                  timelineLayers.rasterStore.layers.push(layer);
+                } else if (layer.slug === "rain") {
+                  timelineLayers.rain = layer;
+                }
+             }
+            });
+          }
+        });
+      }
 
       return timelineLayers;
     };

--- a/app/components/timeline/timeline-service.js
+++ b/app/components/timeline/timeline-service.js
@@ -631,7 +631,7 @@ angular.module('lizard-nxt')
 
       if (circles) {
         var xOneFunction = function (d) {
-          return xScale(parseFloat(d.timestamp) + (d.interval / 2));
+          return xScale(parseFloat(d.timestamp) - (parseFloat(d.interval) / 2));
         };
 
         d3.select("#circle-group").selectAll("circle")
@@ -877,7 +877,7 @@ angular.module('lizard-nxt')
         MAX_COUNT = 100;
 
     var xOneFunction = function (d) {
-      return xScale(parseFloat(d.timestamp) + (aggWindow / 2));
+      return xScale(parseFloat(d.timestamp) - (parseFloat(aggWindow) / 2));
     };
 
     var yFunction = function (d) { return yScale(order); };

--- a/app/components/timeline/timeline-service.js
+++ b/app/components/timeline/timeline-service.js
@@ -631,8 +631,7 @@ angular.module('lizard-nxt')
 
       if (circles) {
         var xOneFunction = function (d) {
-          var interval = 0;
-          return xScale(parseFloat(d.timestamp) + (interval / 2));
+          return xScale(parseFloat(d.timestamp) + (d.interval / 2));
         };
 
         d3.select("#circle-group").selectAll("circle")
@@ -878,7 +877,7 @@ angular.module('lizard-nxt')
         MAX_COUNT = 100;
 
     var xOneFunction = function (d) {
-      return xScale(parseFloat(d.timestamp) - (aggWindow / 2));
+      return xScale(parseFloat(d.timestamp) + (aggWindow / 2));
     };
 
     var yFunction = function (d) { return yScale(order); };
@@ -915,8 +914,6 @@ angular.module('lizard-nxt')
     // UPDATE
     // Update old elements as needed.
     circles.transition()
-      .delay(Timeline.prototype.transTime)
-      .duration(Timeline.prototype.transTime)
       .attr("stroke", color)
       .attr("fill", color)
       .attr("cx", xOneFunction)
@@ -940,12 +937,9 @@ angular.module('lizard-nxt')
     // EXIT
     // Remove old elements as needed.
     circles.exit()
-      .transition()
-      .delay(0)
-      .duration(Timeline.prototype.transTime)
     .transition()
-      .delay(Timeline.prototype.transTime)
       .duration(Timeline.prototype.transTime)
+      .delay(Timeline.prototype.transTime)
       .attr("stroke-width", 0)
       .style("fill-opacity", 0)
       .remove();

--- a/app/lib/event-aggregate-service.js
+++ b/app/lib/event-aggregate-service.js
@@ -179,7 +179,8 @@ angular.module('lizard-nxt')
           .forEach(function (timestamp, value) {
             var tmpObj = {
               timestamp: Number(timestamp) + aggWindow,
-              count: value.count
+              count: value.count,
+              interval: aggWindow
             };
             aggregatedArray.push(tmpObj);
           }

--- a/app/lib/nxt-d3-service.js
+++ b/app/lib/nxt-d3-service.js
@@ -237,7 +237,7 @@ angular.module('lizard-nxt')
      * @return {object} containing the max and min
      */
     _maxMin: function (data, key) {
-      if (data.length < 0) {
+      if (data === null || data.length < 0) {
         return {max: null, min: null};
       }
 

--- a/app/lib/vector-service.js
+++ b/app/lib/vector-service.js
@@ -263,6 +263,9 @@ angular.module('lizard-nxt')
       var result = [];
       data.forEach(function (anno) {
         if (anno.location) {
+          // Make annotations like events and like annotations, to have the best
+          // of both worlds.
+          anno.value = anno.text;
           result.push({
             id: anno.id,
             type: 'Feature',
@@ -279,9 +282,9 @@ angular.module('lizard-nxt')
      */
     var replaceData = function (layerSlug, data, zoom) {
       vectorLayers[layerSlug] = {
-          data: [],
-          zoom: zoom
-        };
+        data: [],
+        zoom: zoom
+      };
       vectorLayers[layerSlug].data = vectorLayers[layerSlug].data.concat(data);
     };
 


### PR DESCRIPTION
- Remove events from timeline when in db, since db shows it in a graph.
- Fix events hopping around freely on the timeline when dragging (long standing bug).
- Fixes a bunch of things that were not broken before.
- Add some ng-if logic to templates to prevent visualising stuff that makes no sense like annotations as events and elevation points in dashboard.