### PR TITLE
Fix bug with search that gives back wrong results

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,13 +7,19 @@ Unreleased (2.9.0) (XXXX-XX-XX)
 - Fix no graph for points in temporal raster.
 
 - Fix no translations in header.
+
 - Fix bootstrap chevron that's missing in dist folder (glyphicon font)
+
 - Fix annotations layer not updating.
 
 - Add choice of organisation when adding an annotation.
 
 - Remove the 'user' from the master controller and inject it only in the
   components that use it.
+
+- Fix weirdness with search. Query now fires search instead of keypress
+
+- Add zoom to api result on ENTER key.
 
 
 Release 2.11.1 (2016-3-25)

--- a/app/components/omnibox/directives/search-directive.js
+++ b/app/components/omnibox/directives/search-directive.js
@@ -135,17 +135,15 @@ angular.module('omnibox')
             scope.zoomToTemporalResult(
               scope.omnibox.searchResults.temporal
             );
-          }
-          else if (loc && loc.spatial && loc.spatial[0]) {
+          } else if (loc && loc.spatial && loc.spatial[0]) {
             scope.zoomToSpatialResult(
               scope.omnibox.searchResults.spatial[0]
             );
+          } else if (loc && loc.api && loc.api[0]) {
+            scope.zoomToSearchResult(
+              scope.omnibox.searchResults.api[0]
+            );
           }
-          else {
-            scope.search();
-          }
-        } else {
-          scope.search();
         }
       }
       prevKey = $event.which;
@@ -223,6 +221,8 @@ angular.module('omnibox')
     var destroySearchResultsModel = function () {
       delete scope.omnibox.searchResults;
     };
+
+    scope.$watch('query', scope.search);
 
   };
 

--- a/app/components/omnibox/directives/search-directive.js
+++ b/app/components/omnibox/directives/search-directive.js
@@ -222,8 +222,6 @@ angular.module('omnibox')
       delete scope.omnibox.searchResults;
     };
 
-    scope.$watch('query', scope.search);
-
   };
 
   return {

--- a/app/components/omnibox/services/search-service.js
+++ b/app/components/omnibox/services/search-service.js
@@ -44,7 +44,6 @@ angular.module('omnibox')
     this.search = function (searchString, state) {
 
       var bounds;
-
       // bounds are not available in the dashboard view.
       if (state.spatial.bounds.getSouth) {
           bounds = // Prefer results from the current viewport

--- a/app/components/omnibox/templates/search.html
+++ b/app/components/omnibox/templates/search.html
@@ -37,6 +37,7 @@
           autocomplete="off"
           dir="ltr"
           ng-model="query"
+          ng-change="search"
           ng-keydown="searchKeyPress($event)"
           spellcheck="false"
           type="search">

--- a/test/spec/date-parser-test.js
+++ b/test/spec/date-parser-test.js
@@ -64,7 +64,10 @@ describe('Service: DateParser', function () {
     var d = dateParser('April');
     var now = new Date();
     expect(d.isValid()).toBe(true);
-    expect(d.calendar()).toBe('01-04-' + now.getFullYear());
+    // don't perform this test around the 1st of April it will break ...
+    if (!(moment(now).dayOfYear() > 90 && moment(now).dayOfYear() < 93)) {
+      expect(d.calendar()).toBe('01-04-' + now.getFullYear());
+    }
   });
 
   it('should contain a duration as interval to zoom to', function () {

--- a/test/spec/search-directive.js
+++ b/test/spec/search-directive.js
@@ -13,6 +13,13 @@ describe('Directives: Search with mocked CabinetService', function () {
         };
       }
     };
+    this.search = {
+      get: function (searchString, spatialState) {
+          return {
+            then: function (cb) { cb({henk: 'hai'}); }
+          };
+      }
+    };
   };
 
   // load the service's module
@@ -44,7 +51,11 @@ describe('Directives: Search with mocked CabinetService', function () {
 
   it('should build query from input field', function () {
     scope.query = "Amsterdam";
-    scope.$digest();
+    // expect it to throw because it triggers a scope watch which according
+    // to the mock ALWAYS returns: OVER_QUERY_LIMIT
+    expect(function () { scope.$digest(); }).toThrow(
+      new Error('Geocoder returned with status: OVER_QUERY_LIMIT')
+    );
     expect(element[0].querySelector('#searchboxinput').value).toBe("Amsterdam");
   });
 

--- a/test/spec/search-directive.js
+++ b/test/spec/search-directive.js
@@ -51,11 +51,7 @@ describe('Directives: Search with mocked CabinetService', function () {
 
   it('should build query from input field', function () {
     scope.query = "Amsterdam";
-    // expect it to throw because it triggers a scope watch which according
-    // to the mock ALWAYS returns: OVER_QUERY_LIMIT
-    expect(function () { scope.$digest(); }).toThrow(
-      new Error('Geocoder returned with status: OVER_QUERY_LIMIT')
-    );
+    scope.$digest();
     expect(element[0].querySelector('#searchboxinput').value).toBe("Amsterdam");
   });
 


### PR DESCRIPTION
* Search was fired on keypress. The query was always one step behind
  Now the query change fires the search.

* Added zoom to api result on ENTER

* Fixed tests for search and dateparser