### PR TITLE
Data menu height to fit in 700px

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changelog of lizard-nxt client
 
 Unreleased (2.9.0) (XXXX-XX-XX)
 -------------------------------
--
+- Fix data menu height
 
 
 Release 3.0.4 (2016-4-5)

--- a/app/styles/_layer-chooser.scss
+++ b/app/styles/_layer-chooser.scss
@@ -28,7 +28,7 @@
 %layer-base {
     float: right;
     min-height: 300px;
-    max-height: 600px;
+    max-height: 450px;
     overflow-y: auto;
     padding: 15px 0 15px 15px;
     background: $clouds;

--- a/app/styles/_layout.scss
+++ b/app/styles/_layout.scss
@@ -60,7 +60,6 @@ a {
 }
 
 .list-group {
-    margin-bottom: 0;
     label {
         font-weight: normal;
     }


### PR DESCRIPTION
* Change data menu height so we can adhere to our advisory height of 700px's