### PR TITLE
Round start & end timestamps on timeseries export URL.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,8 @@ Changelog of lizard-nxt client
 
 Unreleased (2.9.0) (XXXX-XX-XX)
 -------------------------------
--
+
+- Round start & end timestamps on timeseries export URL.
 
 
 Release 3.0.4 (2016-4-5)

--- a/app/components/timeseries/timeseries-directive.js
+++ b/app/components/timeseries/timeseries-directive.js
@@ -51,9 +51,10 @@ angular.module('timeseries')
 
       var selectTimeseries = function () {
         var selectedTimeseries = scope.timeseries.selected.uuid;
-        scope.timeseries.selected.url = window.location.protocol + '//' + window.location.host
-            + '/api/v2/timeseries/' + selectedTimeseries + '/' + 'data/?format=csv&start='
-            + scope.timeState.start + '&end=' + scope.timeState.end ;
+        scope.timeseries.selected.url = window.location.protocol + '//'
+            + window.location.host + '/api/v2/timeseries/' + selectedTimeseries
+            + '/data/?format=csv&start=' + Math.round(scope.timeState.start)
+            + '&end=' + Math.round(scope.timeState.end);
 
         State.selected.timeseries.forEach(function (ts) {
           ts.active = ts.uuid === selectedTimeseries;


### PR DESCRIPTION
Fixes https://github.com/nens/lizard-nxt/issues/1643.

To fix a, probably IE specific, bug that returns decimal numbers for timeState start and end.

No idea whether this actually fixes it, I don't have IE on my computer so cannot reproduce the bug.