### PR TITLE
Set page_size for events requests to 5000.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,8 @@ Changelog of lizard-nxt client
 
 Unreleased (2.9.0) (XXXX-XX-XX)
 -------------------------------
--
+
+- Set page_size for events requests to 5000.
 
 
 Release 3.0.4 (2016-4-5)

--- a/app/lib/cabinet-service.js
+++ b/app/lib/cabinet-service.js
@@ -21,7 +21,6 @@ angular.module('lizard-nxt')
   }
 
   timeseriesResource = new Resource.Endpoint('api/v2/timeseries/');
-  events = new Resource.Endpoint('api/v2/events/?page_size=25000');
   regions = new Resource.Endpoint('api/v2/regions/?page_size=500');
 
   // Wms getFeatureInfo goes through a proxy. Specify url as a param.

--- a/app/lib/vector-service.js
+++ b/app/lib/vector-service.js
@@ -225,7 +225,7 @@ angular.module('lizard-nxt')
         vectorLayers[layerSlug].promise = $http({
           url: layer.url,
           method: 'GET',
-          params: { page_size: 1000 }
+          params: { page_size: 5000 }
         })
         .then(function (response) {
           vectorLayers[layerSlug].isLoading = false;


### PR DESCRIPTION
Fixes https://github.com/nens/lizard-nxt/issues/1652.