### PR TITLE
Update source of grunt-lizard-release.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "grunt-google-cdn": "^0.4.0",
     "grunt-html2js": "~0.2.9",
     "grunt-karma": "~0.12",
-    "grunt-lizard-release": "git://github.com/fritzvd/grunt-lizard-release",
+    "grunt-lizard-release": "git://github.com/nens/grunt-lizard-release",
     "grunt-mrdoc": "~0.1.9",
     "grunt-newer": "^0.7.0",
     "grunt-ng-annotate": "^0.3.0",


### PR DESCRIPTION
Was a repo in FritzVD's Github account and has been moved to NENS.