### PR TITLE
fix https://github.com/nens/lizard-nxt/issues/1638 pass timeState around properly

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,8 @@ Changelog of lizard-nxt client
 
 Unreleased (2.9.0) (XXXX-XX-XX)
 -------------------------------
--
+
+- Fix show a line graph for temporal rasters.
 
 
 Release 3.0.5 (2016-4-11)

--- a/app/components/omnibox/directives/template-directives.js
+++ b/app/components/omnibox/directives/template-directives.js
@@ -348,7 +348,7 @@ angular.module('omnibox')
     restrict: 'E',
     scope: {
       content: '=',
-      state: '=',
+      timeState: '=',
     },
     replace: true,
     templateUrl: 'omnibox/templates/defaultpoint.html'

--- a/app/components/omnibox/templates/defaultpoint.html
+++ b/app/components/omnibox/templates/defaultpoint.html
@@ -31,7 +31,7 @@
         class="card-content"
         line
         type="temporal"
-        temporal="state.temporal"
+        temporal="timeState"
         data="content.data"
         ylabel="content.unit"
         keys="{x: 0, y: 1}">

--- a/app/components/omnibox/templates/geometry-cards.html
+++ b/app/components/omnibox/templates/geometry-cards.html
@@ -25,7 +25,7 @@
     ng-repeat="(slug, content) in geom.properties"
     content="content"
     name="slug"
-    state="omnibox.state">
+    time-state="timeState">
   </defaultpoint>
 
   <div


### PR DESCRIPTION
Ik heb het getest door lokaal mijn regenlayegroup en regen store layer een ander slug te geven en dan wordt het behandeld als een normale temporele raster.