### PR TITLE
Use new portal temporal bounds instead of hardcoded defaults.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,8 @@ Changelog of lizard-nxt client
 
 Unreleased (2.9.0) (XXXX-XX-XX)
 -------------------------------
--
+
+- Use new portal temporal bounds instead of hardcoded defaults.
 
 
 Release 3.0.13 (2016-4-29)

--- a/app/components/state/state-service.js
+++ b/app/components/state/state-service.js
@@ -133,8 +133,8 @@ angular.module('global-state')
 
     // Temporal
     var now = Date.now(),
-        INITIAL_START_FOR_EXTENT = now - 2 * UtilService.day,
-        INITIAL_END_FOR_EXTENT = now + 3 * UtilService.hour;
+        INITIAL_START_FOR_EXTENT = now + window.temporalBounds.start,
+        INITIAL_END_FOR_EXTENT = now + window.temporalBounds.end;
 
     state.temporal = {
       at: now,

--- a/app/components/state/state-service.js
+++ b/app/components/state/state-service.js
@@ -2,8 +2,8 @@
  * Lizard-client global state object.
  */
 angular.module('global-state')
-  .service('State', ['dataLayers', 'UtilService',
-    function (dataLayers, UtilService) {
+  .service('State', ['dataLayers', 'UtilService', 'temporalBounds',
+    function (dataLayers, UtilService, temporalBounds) {
 
     var state = {};
 
@@ -133,8 +133,8 @@ angular.module('global-state')
 
     // Temporal
     var now = Date.now(),
-        INITIAL_START_FOR_EXTENT = now + window.temporalBounds.start,
-        INITIAL_END_FOR_EXTENT = now + window.temporalBounds.end;
+        INITIAL_START_FOR_EXTENT = now + temporalBounds.start,
+        INITIAL_END_FOR_EXTENT = now + temporalBounds.end;
 
     state.temporal = {
       at: now,

--- a/app/lizard-nxt.js
+++ b/app/lizard-nxt.js
@@ -131,3 +131,11 @@ angular.module('lizard-nxt')
  */
 angular.module('lizard-nxt')
   .constant('defaultLocale', window.locale);
+
+/**
+ * @name locale
+ * @memberOf app
+ * @description Portal's default locale.
+ */
+angular.module('lizard-nxt')
+  .constant('temporalBounds', window.temporalBounds);

--- a/test/mocks/beforeModuleMocks.js
+++ b/test/mocks/beforeModuleMocks.js
@@ -4,6 +4,12 @@
 
 window.JS_DEBUG = false;
 
+
+window.temporalBounds = {
+  start: -172800000,
+  end: 10800000
+};
+
 window.data_layers = {
   'satellite': {
     'name': 'Satelliet',


### PR DESCRIPTION
Depends on https://github.com/nens/lizard-nxt/pull/1743/.