### PR TITLE
[Done] Timesteps are now obtained from raster timesteps api endpoint instead…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog of lizard-nxt client
 Unreleased (4.0.2) (XXXX-XX-XX)
 -------------------------------
 
+- Fix bug in timeline. It doesn't use api/v2/raster-aggregates to draw ticks
+  anymore, but api/v2/rasters/[uuid]/timesteps.
+
 - Zap timing console statement.
 
 - Fix rain download href.

--- a/app/components/data-menu/services/raster-data-layer-service.js
+++ b/app/components/data-menu/services/raster-data-layer-service.js
@@ -20,6 +20,9 @@ angular.module('data-menu')
       rasterDataLayer.getData = function (options) {
         return RasterService.getData(_.merge(options, rasterDataLayer));
       };
+      rasterDataLayer.getTimesteps = function (options) {
+        return RasterService.getTimesteps(_.merge(options, rasterDataLayer));
+      };
 
       return rasterDataLayer;
 

--- a/app/components/timeline/timeline-directives.js
+++ b/app/components/timeline/timeline-directives.js
@@ -351,26 +351,19 @@ angular.module('lizard-nxt')
      */
     var getTemporalRasterDates = function (rasterLayers) {
 
-      var start = State.temporal.start,
-          stop = State.temporal.end,
-          bounds = State.spatial.bounds,
-          dates = [];
+      var dates = [];
 
       var draw = function () {
         timeline.drawTickMarks(dates);
       };
 
-      var geom = UtilService.lLatLngToGJ(State.spatial.bounds.getCenter());
-
       rasterLayers.forEach(function (raster) {
-        raster.getData({
+        raster.getTimesteps({
           start: State.temporal.start,
-          end: State.temporal.end,
-          geom: geom,
-          truncate: true,
+          end: State.temporal.end
         }).then(function (response) {
           if (response && response !== 'null') {
-            dates = dates.concat(response.data);
+            dates = dates.concat(response.data.steps);
           }
           draw(dates);
         });

--- a/app/lib/raster-service.js
+++ b/app/lib/raster-service.js
@@ -64,7 +64,6 @@ angular.module('lizard-nxt')
     } else {
       requestOptions.geom = UtilService.geomToWkt(options.geom);
     }
-    console.log(CabinetService.raster(canceler).get(requestOptions));
     return CabinetService.raster(canceler).get(requestOptions);
   };
 

--- a/app/lib/raster-service.js
+++ b/app/lib/raster-service.js
@@ -7,7 +7,8 @@ angular.module('lizard-nxt')
                              "CabinetService",
                              "LeafletService",
                              "$q",
-  function (State, UtilService, CabinetService, LeafletService, $q) {
+                             "$http",
+  function (State, UtilService, CabinetService, LeafletService, $q, $http) {
 
   var intensityData,
       cancelers = {};
@@ -63,12 +64,16 @@ angular.module('lizard-nxt')
     } else {
       requestOptions.geom = UtilService.geomToWkt(options.geom);
     }
-
-    if (options.truncate === true) {
-      requestOptions.truncate = options.truncate;
-    }
-
+    console.log(CabinetService.raster(canceler).get(requestOptions));
     return CabinetService.raster(canceler).get(requestOptions);
+  };
+
+  var getTimesteps = function (options) {
+    return $http({
+        method: 'GET',
+        url: 'api/v2/rasters/' + options.uuid + '/timesteps/',
+        params: {start: options.start, end: options.end}
+      });
   };
 
   /**
@@ -130,6 +135,7 @@ angular.module('lizard-nxt')
   return {
     buildURLforWMS: buildURLforWMS,
     getData: getData,
+    getTimesteps: getTimesteps
   };
 
 }]);


### PR DESCRIPTION
… of raster-aggregates.

- front end aanpassen: hier wordt api/v2/raster-aggregates bevraagd voor de tickmarks. dat moet dus `api/v2/rasters/[uuid]/timesteps/` inclusief timebounds worden.
- `truncate=true`-filter op raster-aggregates verwijderen als het inderdaad alleen voor de tickmarks gebruikt wordt


fixes: https://github.com/nens/lizard-nxt/issues/1799
related to: https://github.com/nens/lizard-nxt/pull/1881