### PR TITLE
Raster wms tiles now respect the slug.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog of lizard-nxt client
 Unreleased (4.1.1) (XXXX-XX-XX)
 -------------------------------
 
+- Fix nens/lizard-nxt#1955. Raster wms tiles now respect the slug.
+
 - Set the right display names for the changed scenarios
 
 - Add inbox to the frontend. Messages contain async downloads

--- a/app/components/data-menu/layer-directives/rasterlayer-directive.js
+++ b/app/components/data-menu/layer-directives/rasterlayer-directive.js
@@ -21,6 +21,7 @@ angular.module('data-menu')
           var mapLayer = rasterMapLayer({
             uuid: scope.layer.uuid,
             url: 'api/v2/wms/',
+            slug: response.slug,
             bounds: response.spatial_bounds,
             temporal: response.temporal,
             frequency: response.frequency,

--- a/app/components/map/services/raster-map-layer-service.js
+++ b/app/components/map/services/raster-map-layer-service.js
@@ -107,6 +107,7 @@ angular.module('map')
             date = new Date(rasterMapLayer._mkTimeStamp(timeState.at));
 
         var defaultOptions = {
+          layers: rasterMapLayer.slug,
           format: 'image/png',
           version: '1.1.1',
           minZoom: 0,


### PR DESCRIPTION
Fix nens/lizard-nxt#1955.