### PR TITLE
context-dependent 'Map' vs 'Dashboard' button

### DIFF
--- a/app/components/user-menu/user-menu.html
+++ b/app/components/user-menu/user-menu.html
@@ -31,12 +31,12 @@
         </li>
         <li>
           <a ng-click="toggleDashboard()"
-             title="<% 'Switch to dashboard' | translate %>"
+             title="<% 'Switch to ' + getContextComplement() | translate %>"
              target="_blank"
              accesskey="d"
              href="">
             <i class="fa fa-bar-chart"></i>
-            <span translate>Dashboard</span>
+            <span translate><% getContextComplement() %></span>
           </a>
         </li>
         <li ng-if="user.authenticated"

--- a/app/lizard-nxt-master-controller.js
+++ b/app/lizard-nxt-master-controller.js
@@ -92,6 +92,10 @@ angular.module('lizard-nxt')
     $scope.transitionToContext(($scope.context === 'map') ? 'dashboard' : 'map');
   };
 
+  $scope.getContextComplement = function () {
+    return $scope.context === 'map' ? 'Dashboard' : 'Map';
+  };
+
   // END CONTEXT
 
   $scope.toggleVersionVisibility = function () {


### PR DESCRIPTION
The user-menu can show two different texts on the 'switch states button'. Which one is currently shown depends on the current state. 