### PR TITLE
Fix missing agg request parameter.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,11 +3,13 @@ Changelog of lizard-nxt client
 
 Unreleased (4.2.0) (XXXX-XX-XX)
 -------------------------------
--
+
+- Fix missing agg request parameter.
 
 
 Release 4.1.5 (2016-9-30)
 ---------------------
+
 -
 
 

--- a/app/lib/raster-service.js
+++ b/app/lib/raster-service.js
@@ -16,7 +16,7 @@ angular.module('lizard-nxt')
   var getData = function (options) {
 
     var srs = 'EPSG:4326',
-        agg = options.agg || '',
+        agg = options.aggType || '',
         startString,
         endString,
         aggWindow;


### PR DESCRIPTION
Currently, the agg request parameter is empty:

`api/v2/raster-aggregates/?agg=&...`

It should be something like this:

`api/v2/raster-aggregates/?agg=counts&...`

`api/v2/raster-aggregates/?agg=curve&...`

Etc.