### PR TITLE
Fix rain statistics.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,11 +3,13 @@ Changelog of lizard-nxt client
 
 Unreleased (4.2.0) (XXXX-XX-XX)
 -------------------------------
--
+
+- Fix rain statistics.
 
 
 Release 4.1.9 (2016-10-4)
 ---------------------
+
 - Fix graphs for raster aggregate data.
 
 - Fix missing styles parameter.

--- a/app/lib/raster-service.js
+++ b/app/lib/raster-service.js
@@ -16,7 +16,7 @@ angular.module('lizard-nxt')
   var getData = function (options) {
 
     var srs = 'EPSG:4326',
-        agg = options.aggType || '',
+        agg = options.agg || options.aggType || '',
         startString,
         endString,
         aggWindow;


### PR DESCRIPTION
Fixes: https://github.com/nens/lizard-nxt/issues/1996

____________

Gisteren heb ik een bug kunnen fixen door agg in aggType te veranderen:

https://github.com/nens/lizard-client/pull/702/files

Een andere bug kan ik echter alleen oplossen door aggType in agg te wijzigen:

https://github.com/nens/lizard-nxt/issues/1996

@berto-nens : Had jij ook niet lopen klooien met deze inconsistencies?

Als @ernstkui  terug is, mag hij zijn licht hierover laten schijnen. Tot die tijd maak ik er denk ik maar dit van:

agg = options.agg || options.aggType || ''