### PR TITLE
Fix landuse for multipolygons.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Unreleased (4.2.0) (XXXX-XX-XX)
 
 - Fix icon to switch from dashboard to map is incorrect.
 
+- Fix landuse graph not working for multipolygons (#1942).
+
 
 Release 4.1.9 (2016-10-4)
 ---------------------

--- a/app/components/data-menu/services/data-service.js
+++ b/app/components/data-menu/services/data-service.js
@@ -316,7 +316,7 @@ angular.module('data-menu')
 
         options.geom = geo.geometry;
 
-        if (geo.geometry && geo.geometry.type === 'Polygon' && geo.id) {
+        if (geo.geometry && (geo.geometry.type === 'Polygon' || geo.geometry.type === 'MultiPolygon') && geo.id) {
           options.id = geo.id;
         }
 


### PR DESCRIPTION
Fixes https://github.com/nens/lizard-nxt/issues/1942.

ECMA 6 supports endsWith:

```
if (geo.geometry && geo.geometry.type.endsWith('Polygon') && geo.id) {
  ...
}
```