### PR TITLE
Fix layers hidden by base layers.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,8 @@ Changelog of lizard-nxt client
 
 Unreleased (4.2.0) (XXXX-XX-XX)
 -------------------------------
--
+
+- Fix base layers hiding other layers (#1998).
 
 
 Release 4.1.10 (2016-10-7)

--- a/app/components/map/services/map-service.js
+++ b/app/components/map/services/map-service.js
@@ -42,9 +42,9 @@ angular.module('map')
       mapLayers: [],
 
       baselayers: [
-        baselayer({ id: 'topography', url: topography }),
-        baselayer({ id: 'satellite', url: satellite }),
-        baselayer({ id: 'neutral', url: neutral }),
+        baselayer({ id: 'topography', url: topography, zIndex: -1 }),
+        baselayer({ id: 'satellite', url: satellite, zIndex: -1 }),
+        baselayer({ id: 'neutral', url: neutral, zIndex: -1 }),
       ],
 
       /**


### PR DESCRIPTION
Fixes https://github.com/nens/lizard-nxt/issues/1998.

NB:

I don't understand why setting the zIndex to 0 does not solve the problem, while a zIndex of -1 does. Other layers seem to have a proper zIndex (high numbers, not 0).