### PR TITLE
Ernst revert dashboard timeseries empty non empty

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,8 @@ Changelog of lizard-nxt client
 
 Unreleased (4.2.0) (XXXX-XX-XX)
 -------------------------------
--
+
+- Undo changes to add timeseries to dashboard when switching from map.
 
 
 Release 4.1.14 (2016-10-10)

--- a/app/components/omnibox/directives/db-asset-card-directive.js
+++ b/app/components/omnibox/directives/db-asset-card-directive.js
@@ -43,12 +43,13 @@ angular.module('omnibox')
        * view (screen no longer shows up blank..)
        */
       if (!scope.noTimeseries) {
-        _.forEach(State.selected.timeseries, function (ts) {
-          // de volgordes zijn niet altijd hetzelfde, dus uuid maaakt het 100% certain
-          var assetTS = _.find(scope.asset.timeseries, {uuid: ts.uuid});
-          TimeseriesService.timeseries.push(assetTS);
+        var ts;
+        TimeseriesService.initializeTimeseriesOfAsset(scope.asset);
+        for (var i=0; i<State.selected.timeseries.length; i++) {
+          ts = State.selected.timeseries[i];
+          TimeseriesService.timeseries.push(scope.asset.timeseries[i]);
           scope.toggleTimeseries(ts);
-        });
+        }
       }
 
       /**

--- a/app/components/omnibox/directives/db-asset-card-directive.js
+++ b/app/components/omnibox/directives/db-asset-card-directive.js
@@ -44,16 +44,12 @@ angular.module('omnibox')
        */
       if (!scope.noTimeseries) {
         TimeseriesService.initializeTimeseriesOfAsset(scope.asset);
-
-        var tsViaAsset = _.find(scope.asset.timeseries, {
-          uuid: TimeseriesService.selectedTimeseriesUuid
-        })
-        TimeseriesService.timeseries.push(tsViaAsset);
-
-        var tsViaState = _.find(State.selected.timeseries, {
-          uuid: TimeseriesService.selectedTimeseriesUuid
+        _.forEach(State.selected.timeseries, function (ts) {
+          // de volgordes zijn niet altijd hetzelfde, dus uuid maakt het 100% certain
+          var assetTS = _.find(scope.asset.timeseries, {uuid: ts.uuid});
+          TimeseriesService.timeseries.push(assetTS);
+          scope.toggleTimeseries(ts);
         });
-        scope.toggleTimeseries(tsViaState);
       }
 
       /**

--- a/app/components/omnibox/directives/db-asset-card-directive.js
+++ b/app/components/omnibox/directives/db-asset-card-directive.js
@@ -43,9 +43,8 @@ angular.module('omnibox')
        * view (screen no longer shows up blank..)
        */
       if (!scope.noTimeseries) {
-        TimeseriesService.initializeTimeseriesOfAsset(scope.asset);
         _.forEach(State.selected.timeseries, function (ts) {
-          // de volgordes zijn niet altijd hetzelfde, dus uuid maakt het 100% certain
+          // de volgordes zijn niet altijd hetzelfde, dus uuid maaakt het 100% certain
           var assetTS = _.find(scope.asset.timeseries, {uuid: ts.uuid});
           TimeseriesService.timeseries.push(assetTS);
           scope.toggleTimeseries(ts);

--- a/app/components/omnibox/directives/db-asset-card-directive.js
+++ b/app/components/omnibox/directives/db-asset-card-directive.js
@@ -39,20 +39,6 @@ angular.module('omnibox')
       scope.noTimeseries = scope.asset.timeseries.length === 0;
 
       /**
-       * Render all timeseries for selected asset when switching to dashboard
-       * view (screen no longer shows up blank..)
-       */
-      if (!scope.noTimeseries) {
-        var ts;
-        TimeseriesService.initializeTimeseriesOfAsset(scope.asset);
-        for (var i=0; i<State.selected.timeseries.length; i++) {
-          ts = State.selected.timeseries[i];
-          TimeseriesService.timeseries.push(scope.asset.timeseries[i]);
-          scope.toggleTimeseries(ts);
-        }
-      }
-
-      /**
        * Specific toggle for crosssection
        *
        * @param  {object} asset with entity_name crossection and a crossection

--- a/app/components/timeseries/timeseries-directive.js
+++ b/app/components/timeseries/timeseries-directive.js
@@ -78,7 +78,7 @@ angular.module('timeseries')
         });
 
         TimeseriesService.syncTime().then(getContentForAsset);
-        TimeseriesService.selectedTimeseriesUuid = selectedTimeseriesUuid;
+
       };
 
       var getContentForAsset = function (timeseries) {

--- a/app/components/timeseries/timeseries-service.js
+++ b/app/components/timeseries/timeseries-service.js
@@ -20,16 +20,13 @@ angular.module('timeseries')
 
     this.minPoints = GRAPH_WIDTH; // default
 
-    // Save the UUID for the ts rendered in the omnibox, so we can auto-render
-    // it when switching to the Dashboard context.
-    this.selectedTimeseriesUuid = null;
-
     var service = this;
 
     var _timeseries = [];
     Object.defineProperty(State.selected, 'timeseries', {
       get: function () { return _timeseries; },
       set: function (timeseries) {
+        console.log('State.selected.timeseries:', timeseries);
         _timeseries = timeseries;
         service.syncTime(timeseries);
       },
@@ -60,6 +57,7 @@ angular.module('timeseries')
 
       promise.then(function (ts) {
         service.timeseries = ts;
+        console.log('TimeseriesService.timeseries:', service.timeseries);
       })
 
 


### PR DESCRIPTION
I don't know how it was supposed to function, but this is what it does now:

![ts-select](https://cloud.githubusercontent.com/assets/4438154/19235888/a7aaa862-8ef4-11e6-9d0c-5075f1f3a645.gif)


Fixes: https://github.com/nens/lizard-nxt/issues/2010