### PR TITLE
No asset removal on switch from db to map

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog of lizard-nxt client
 Unreleased (4.2.0) (XXXX-XX-XX)
 -------------------------------
 
+- When user switches back to map context after having selected more
+  than one asset while in db context, the box.type and tool switch to
+  'multi-point'.
+
 - Fix rain statistics.
 
 - Fix icon to switch from dashboard to map is incorrect.

--- a/app/components/data-menu/services/asset-service.js
+++ b/app/components/data-menu/services/asset-service.js
@@ -5,6 +5,8 @@ angular.module('data-menu')
   .service("AssetService", ['State', '$q', '$http',
     function (State, $q, $http) {
 
+      this.NESTED_ASSET_PREFIXES = ['pump', 'filter', 'monitoring_well'];
+
       /**
        * Removes all the ts from the selection of the asset. It should not be
        * possible to select ts of assets.
@@ -90,9 +92,35 @@ angular.module('data-menu')
           defer.resolve();
           return [defer.promise];
         }
-
       };
 
-  }
+      /**
+       * Given State.selected.assets, get the names for the assets that are
+       * nested within other assets (e.g. 'filter$23').
+       *
+       * @return {array} Names of currently selected assets that are nested.
+       */
+      this.getNestedAssets = function () {
+        var nestedAssetPrefixes = this.NESTED_ASSET_PREFIXES,
+            nestedAssetNames = [];
+        State.selected.assets.forEach(function (assetName) {
+          nestedAssetPrefixes.forEach(function (nestedAssetPrefix) {
+            if (assetName.startsWith(nestedAssetPrefix)) {
+              nestedAssetNames.push(assetName);
+            }
+          });
+        });
+        return nestedAssetNames;
+      };
 
+      /**
+       * Given State.selected.assets, get the names for the assets that are not
+       * nested within other assets (e.g. 'pumpstation$303').
+       *
+       * @return {array} Names of currently selected assets that aren't nested.
+       */
+      this.getNonNestedAssets = function () {
+        return _.difference(State.selected.assets, this.getNestedAssets());
+      };
+  }
 ]);

--- a/app/components/data-menu/services/data-service.js
+++ b/app/components/data-menu/services/data-service.js
@@ -77,7 +77,6 @@ angular.module('data-menu')
         rebindAssetFunctions();
       };
 
-
       // Rebind add and remove because selected.assets might have been
       // redefined when calling state.selected.assets = []
       var rebindAssetFunctions = function () {

--- a/app/components/data-menu/services/data-service.js
+++ b/app/components/data-menu/services/data-service.js
@@ -23,14 +23,12 @@ angular.module('data-menu')
     'AssetService',
     'LayerAdderService',
     'State',
-    'getNestedAssets',
 
     function (
       $q,
       AssetService,
       LayerAdderService,
-      State,
-      getNestedAssets
+      State
     ) {
 
       var instance = this;

--- a/app/components/omnibox/directives/db-nested-asset-directive.js
+++ b/app/components/omnibox/directives/db-nested-asset-directive.js
@@ -28,7 +28,7 @@ angular.module('omnibox')
           State.selected.assets.addAsset(asset.entity_name + '$' + asset.id);
           return asset;
         });
-      })
+      });
 
       scope.$on('$destroy', function () {
         nestedAssets.forEach(function (asset) {

--- a/app/components/omnibox/services/nested-asset-service.js
+++ b/app/components/omnibox/services/nested-asset-service.js
@@ -47,8 +47,6 @@ angular.module('omnibox')
       });
 
       return nestedAssets;
-
     };
-
   }
 ]);

--- a/app/lizard-nxt-master-controller.js
+++ b/app/lizard-nxt-master-controller.js
@@ -121,7 +121,7 @@ angular.module('lizard-nxt')
     if ($window.location.host === 'portal.ddsc.nl') {
       application = 'DDSC';
     }
-    var portal = $window.location.host.split('.')[0]
+    var portal = $window.location.host.split('.')[0];
     portal = portal.charAt(0).toUpperCase() + portal.slice(1);
     return application + ' ' + portal;
   };

--- a/app/lizard-nxt-master-controller.js
+++ b/app/lizard-nxt-master-controller.js
@@ -26,6 +26,7 @@ angular.module('lizard-nxt')
    'MapService',
    'rmAllButLastAssetAndGeometry',
    'UrlService',
+   'AssetService',
 
   function ($scope,
             $rootScope,
@@ -37,7 +38,8 @@ angular.module('lizard-nxt')
             State,
             MapService,
             rmAllButLastAssetAndGeometry,
-            UrlService) {
+            UrlService,
+            AssetService) {
 
   $scope.version = version;
   $scope.tooltips = CabinetService.createTooltips();
@@ -63,6 +65,11 @@ angular.module('lizard-nxt')
   $scope.transitionToContext = function (context) {
     if (context !== State.context) {
       State.context = context;
+      if (context === 'map' && AssetService.getNonNestedAssets().length > 1) {
+        // If more than one asset became selected when user was in db context,
+        // we switch the box-type/tool to 'multi-point':
+        State.box.type = 'multi-point';
+      }
     }
 
     var overlay = angular.element('#context-transition-overlay')[0];

--- a/app/lizard-nxt-master-controller.js
+++ b/app/lizard-nxt-master-controller.js
@@ -63,10 +63,8 @@ angular.module('lizard-nxt')
   $scope.transitionToContext = function (context) {
     if (context !== State.context) {
       State.context = context;
-      if (State.context === 'map' && State.box.type === 'point') {
-        rmAllButLastAssetAndGeometry();
-      }
     }
+
     var overlay = angular.element('#context-transition-overlay')[0];
     overlay.style.transition = null;
     overlay.style.minHeight = window.innerHeight + 'px';


### PR DESCRIPTION
When selecting more than one asset while in db context, when switching back to map context all but one asset got removed from the selected assets. Now all selected assets get shown, and the tool/box-type switches to 'multi-point' to keep the user experience consistent.