### PR TITLE
[DONE] Fixes notie global

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -199,7 +199,7 @@ module.exports = function (grunt) {
       dev: {
         options: {
           reporter: require('jshint-stylish'),
-          reporterOutput: null
+          reporterOutput: ""
         },
         src: [
           'Gruntfile.js',

--- a/app/components/timeseries/timeseries-directive.js
+++ b/app/components/timeseries/timeseries-directive.js
@@ -50,8 +50,8 @@ angular.module('timeseries')
 
 
 .directive('timeseriesSingleSelect', ['$http', 'State', 'TimeseriesService',
-  'gettextCatalog',
-  function ($http, State, TimeseriesService, gettextCatalog) {
+  'gettextCatalog', 'notie',
+  function ($http, State, TimeseriesService, gettextCatalog, notie) {
   return {
     link: function (scope) {
 
@@ -155,4 +155,3 @@ angular.module('timeseries')
     scope: true // Share scope with timeseries directive
   };
 }]);
-


### PR DESCRIPTION
[Notie](https://github.com/jaredreich/notie) was used from the `window` object in [timeseries-directive.js](https://github.com/nens/lizard-client/blob/master/app/components/timeseries/timeseries-directive.js). This caused jshint to show errors in the build process.

This PR injects `notie` into the directive to solve the problem.