### PR TITLE
fix(ommnibox): more robust precision conversion when dealing with nulls

### DIFF
--- a/app/components/omnibox/templates/defaultpoint.html
+++ b/app/components/omnibox/templates/defaultpoint.html
@@ -7,7 +7,7 @@
           class="table table-condensed table-hover single-row-table">
           <thead>
             <td class="col-md-4"><% content.quantity %> </td>
-            <td class="col-md-4"><% content.data[0].toPrecision(3) %> <% content.unit %></td>
+            <td class="col-md-4"><% content.data[0] ? content.data[0].toPrecision(3) : content.data[0] %> <% content.unit %></td>
             <td class="col-md-4"></td>
           </thead>
         </table>


### PR DESCRIPTION
Dit is een optioneel PR. Zonder dit werkt het ook met ``null`` waarden, maar dit is misschien wat netter.