### PR TITLE
[DONE] Unhides the zoombuttons and positions them next to the search input

### DIFF
--- a/app/components/omnibox/templates/search.html
+++ b/app/components/omnibox/templates/search.html
@@ -1,5 +1,5 @@
 <div class="searchbox" id="searchbox" role="search">
-  <div class="zoom-buttons material-shadow hide">
+  <div class="zoom-buttons material-shadow">
     <button class="btn btn-primary"
             ng-click="zoomIn()"
             accesskey="+"

--- a/app/styles/_searchbox.scss
+++ b/app/styles/_searchbox.scss
@@ -65,7 +65,7 @@ $zoombutton-width: 30px;
     float: right;
 
     height: $searchbox-height;
-    margin-left: $searchbox-margins;
+    margin-left: 0;
     text-align: center;
 
     button {


### PR DESCRIPTION
The new UX expects them in another place, but we'll do that later..

It looks like this:

![screen shot 2016-12-13 at 12 02 18](https://cloud.githubusercontent.com/assets/7193/21137924/102fa054-c12c-11e6-96cb-b13eef9bfbd8.jpg)
