### PR TITLE
[Done] Fix duplicate timeseries in dashboard export modal.

### DIFF
--- a/app/components/export/export-directive.js
+++ b/app/components/export/export-directive.js
@@ -5,7 +5,7 @@ angular.module('export')
   var link = function (scope) {
     // bind the assets with the selected things from the DataService
     scope.assets = DataService.assets;
-    scope.isMap = State.context == 'map';
+    scope.isMap = State.context === 'map';
 
     // Start and end of data
     var timeState = {

--- a/app/components/export/export-directive.js
+++ b/app/components/export/export-directive.js
@@ -5,6 +5,7 @@ angular.module('export')
   var link = function (scope) {
     // bind the assets with the selected things from the DataService
     scope.assets = DataService.assets;
+    scope.isMap = State.context == 'map';
 
     // Start and end of data
     var timeState = {

--- a/app/components/export/export-selector.html
+++ b/app/components/export/export-selector.html
@@ -23,7 +23,7 @@
         <input ng-model="toExport[ts.uuid]" type="checkbox">
         <span><% ts.location %>, <% ts.name %>, <% ts.parameter %></span>
       </div>
-      <div ng-repeat="filter in asset.filters">
+      <div ng-repeat="filter in asset.filters" ng-if="isMap">
         <div ng-repeat="fts in filter.timeseries">
           <input ng-model="toExport[fts.uuid]" type="checkbox">
           <span><% fts.location %>, <% fts.name %>, <% fts.parameter %></span>


### PR DESCRIPTION
Export modal now only iterates over nested asset timeseries if in the Map context. Fixes: nens/lizard-nxt/issues/2086