### PR TITLE
fix(zoom buttons): move out of search bar and show only when in map context

### DIFF
--- a/app/components/omnibox/directives/search-directive.js
+++ b/app/components/omnibox/directives/search-directive.js
@@ -8,11 +8,10 @@ angular.module('omnibox')
   .directive('search', [
     'SearchService',
     'ClickFeedbackService',
-    'MapService',
     'State',
     'UtilService',
     '$timeout',
-  function (SearchService, ClickFeedbackService, MapService, State,
+  function (SearchService, ClickFeedbackService, State,
     UtilService, $timeout) {
 
   var link = function (scope, element, attrs) {
@@ -34,10 +33,6 @@ angular.module('omnibox')
 
     // Set focus on search input field.
     element.children()[0].focus();
-
-    // Bind mapservice functions for zoom buttons;
-    scope.zoomIn = MapService.zoomIn;
-    scope.zoomOut = MapService.zoomOut;
 
     /**
      * Uses scope.query to search for results through SearchService. Response

--- a/app/components/omnibox/templates/search.html
+++ b/app/components/omnibox/templates/search.html
@@ -1,6 +1,6 @@
 <div class="searchbox" id="searchbox" role="search">
 
-  <div class="resize-wrapper material-shadow">
+  <div class="resize-wrapper">
     <div class="search-and-close">
       <button class="btn btn-default btn-lg clear-search"
               type="button"

--- a/app/components/omnibox/templates/search.html
+++ b/app/components/omnibox/templates/search.html
@@ -1,19 +1,4 @@
 <div class="searchbox" id="searchbox" role="search">
-  <div class="zoom-buttons material-shadow">
-    <button class="btn btn-primary"
-            ng-click="zoomIn()"
-            accesskey="+"
-            tabindex="0"
-            aria-label="<% tooltips.zoomInMap %>">
-      <i class="fa fa-plus"></i>
-    </button>
-    <button class="btn btn-primary"
-            ng-click="zoomOut()"
-            accesskey="-"
-            aria-label="<% tooltips.zoomOutMap %>">
-      <i class="fa fa-minus"></i>
-    </button>
-  </div>
 
   <div class="resize-wrapper material-shadow">
     <div class="search-and-close">

--- a/app/components/user-menu/user-menu-directive.js
+++ b/app/components/user-menu/user-menu-directive.js
@@ -6,6 +6,7 @@ angular.module('user-menu')
   .directive('userMenu',[
     '$http',
     'UtilService',
+    'MapService',
     '$location',
     'user',
     '$uibModal',
@@ -15,6 +16,7 @@ angular.module('user-menu')
     function (
       $http,
       UtilService,
+      MapService,
       $location,
       user,
       $uibModal,
@@ -32,6 +34,10 @@ angular.module('user-menu')
       };
 
       scope.inbox = [];
+
+      // Bind mapservice functions for zoom buttons;
+      scope.zoomIn = MapService.zoomIn;
+      scope.zoomOut = MapService.zoomOut;
 
       /**
        * Turn off either favourites or apps when click the on or the other

--- a/app/components/user-menu/user-menu.html
+++ b/app/components/user-menu/user-menu.html
@@ -1,4 +1,19 @@
 <nav class="navbar navbar-default fullnavbar">
+  <div class="zoom-buttons" ng-show="state.context === 'map'">
+    <button class="btn btn-primary"
+            ng-click="zoomIn()"
+            accesskey="+"
+            tabindex="0"
+            aria-label="<% tooltips.zoomInMap %>">
+      <i class="fa fa-plus"></i>
+    </button>
+    <button class="btn btn-primary"
+            ng-click="zoomOut()"
+            accesskey="-"
+            aria-label="<% tooltips.zoomOutMap %>">
+      <i class="fa fa-minus"></i>
+    </button>
+  </div>
   <div id="lizard-apps-container" class="lizard-apps-container material-shadow"></div>
   <div style="margin-right:15px;width:100%;">
     <div class="navbar-header">

--- a/app/styles/_navbar.scss
+++ b/app/styles/_navbar.scss
@@ -82,3 +82,32 @@ $grid-float-breakpoint-max: 768px;
 .user-name {
   margin-left: -10px;
 }
+
+
+.zoom-buttons {
+    position: absolute;
+    left: 400px;
+    height: $searchbox-height;
+    margin-left: 0;
+    text-align: center;
+
+    button {
+        display: block;
+        height: $searchbox-height / 2;
+        width: $zoombutton-width;
+        padding: 0;
+        background-color: $greenSea;
+        color: $white;
+        border: none;
+        border-radius: 0;
+
+        &:hover, &:active {
+            color: $white;
+            background-color: $turquoise;
+            @include material-shadow-hover();
+        }
+        &:focus {
+            background-color: $greenSea;
+        }
+    }
+}

--- a/app/styles/_omnibox.scss
+++ b/app/styles/_omnibox.scss
@@ -210,7 +210,6 @@
 #cards {
   position: relative;
   width: 400px;
-  margin-top: -2px;
   outline: none;
   background: none;
   opacity: 1;

--- a/app/styles/_searchbox.scss
+++ b/app/styles/_searchbox.scss
@@ -61,34 +61,6 @@ $zoombutton-width: 30px;
     }
 }
 
-.zoom-buttons {
-    float: right;
-
-    height: $searchbox-height;
-    margin-left: 0;
-    text-align: center;
-
-    button {
-        display: block;
-        height: $searchbox-height / 2;
-        width: $zoombutton-width;
-        padding: 0;
-        background-color: $greenSea;
-        color: $white;
-        border: none;
-        border-radius: 0;
-
-        &:hover, &:active {
-            color: $white;
-            background-color: $turquoise;
-            @include material-shadow-hover();
-        }
-        &:focus {
-            background-color: $greenSea;
-        }
-    }
-}
-
 .search-results {
   position: absolute;
   z-index: 9999;


### PR DESCRIPTION
I thought I should try to move the zoombuttons to a slightly better spot and hide them when not in map. It is still not very good, but it no longer messes with the layout in dashboard.

There was a lost 2px negative margin which made the searchresults overlap the navbar.

I also removed material-shadow from the search, I think that is what made it look crooked. 
