### PR TITLE
Searchbox 'looking glass'

### DIFF
--- a/app/components/omnibox/directives/omnibox-directives.js
+++ b/app/components/omnibox/directives/omnibox-directives.js
@@ -15,7 +15,7 @@ angular.module("omnibox")
         ESC: 27,
         UPARROW: 38,
         DOWNARROW: 40,
-        RETURNKEY: 13,
+        RETURNKEY: 13
       };
 
       scope.onFocus = function(item, $event) {

--- a/app/components/omnibox/templates/db-asset-card.html
+++ b/app/components/omnibox/templates/db-asset-card.html
@@ -28,11 +28,11 @@
       </dl>
     </div>
 
-    <em class="card-content-list"
+    <div class="card-content-list"
         ng-if="noTimeseries && asset.entity_name !== 'leveecrosssection'"
         translate>
-      No timeseries available for this asset
-    </em>
+      <em>No timeseries available for this asset</em>
+    </div>
 
     <div id="drag-container" ng-if="!noTimeseries">
 

--- a/app/components/omnibox/templates/search-results.html
+++ b/app/components/omnibox/templates/search-results.html
@@ -1,6 +1,6 @@
 <div class="card active">
 
-  <div class="search-results"
+  <div class="search-results material-shadow"
        ng-keydown="onKeydown($event)"
        ng-focus="onFocus(item)">
 

--- a/app/components/omnibox/templates/search.html
+++ b/app/components/omnibox/templates/search.html
@@ -9,7 +9,9 @@
               ng-if="query"
               accesskey="q"
               id="clear">
-        <span aria-hidden="true">&times;</span>
+        <span aria-hidden="true">
+          <i class="fa fa-times"></i>
+        </span>
       </button>
       <div class="resize-wrapper">
         <input
@@ -24,9 +26,15 @@
           spellcheck="false"
           tabindex="0"
           type="search" />
-          <span ng-if="!query" class="search-looking-glass">
-            <i class="fa fa-search" aria-hidden="true"></i>
-          </span>
+          <button class="btn btn-default btn-lg clear-search"
+                  type="button"
+                  ng-if="!query"
+                  accesskey="q"
+                  id="clear">
+            <span ng-if="!query" class="search-looking-glass">
+              <i class="fa fa-search" aria-hidden="true"></i>
+            </span>
+          </button>
       </div>
     </div>
   </div>

--- a/app/components/omnibox/templates/search.html
+++ b/app/components/omnibox/templates/search.html
@@ -38,7 +38,10 @@
           ng-keydown="searchKeyPress($event)"
           spellcheck="false"
           tabindex="0"
-          type="search">
+          type="search" />
+          <span ng-if="!query" class="search-looking-glass">
+            <i class="fa fa-search" aria-hidden="true"></i>
+          </span>
       </div>
     </div>
   </div>

--- a/app/styles/_bootstrap-overrides.scss
+++ b/app/styles/_bootstrap-overrides.scss
@@ -1,3 +1,7 @@
 .modal-title {
   text-transform: capitalize;
 }
+input::-webkit-input-placeholder { color: #ccc !important; }
+input:-moz-placeholder { color: #ccc !important; }
+input::-moz-placeholder { color: #ccc !important; }
+input:-ms-input-placeholder { color: #ccc !important; }

--- a/app/styles/_searchbox.scss
+++ b/app/styles/_searchbox.scss
@@ -5,29 +5,28 @@ $zoombutton-width: 30px;
 .searchbox {
     height: $searchbox-height;
 
+
     .resize-wrapper {
         overflow: hidden;
     }
 
     .search-looking-glass {
       position: absolute;
-      right: 10px;
-      top: 14px;
-      color: $asbestos;
+      right: 15px;
+      top: 13px;
+      color: $silver;
     }
 
     .search-and-close {
         height: $searchbox-height;
         width: 100%;
         background: $white;
-        background: rgba($white, 0.95);
 
         input {
             height: $searchbox-height - (2 * $searchbox-margins);
             width: 100%;
             margin-top: $searchbox-margins;
             padding: 0 15px;
-            background: transparent;
             color: $asbestos;
             border: none;
             &:focus {

--- a/app/styles/_searchbox.scss
+++ b/app/styles/_searchbox.scss
@@ -9,6 +9,13 @@ $zoombutton-width: 30px;
         overflow: hidden;
     }
 
+    .search-looking-glass {
+      position: absolute;
+      right: 10px;
+      top: 14px;
+      color: $asbestos;
+    }
+
     .search-and-close {
         height: $searchbox-height;
         width: 100%;


### PR DESCRIPTION
- Adds a looking glass when the search input has no focus/value.
- Dims bootstrap placeholder color
- Search background is actually white opaque now (as designed)
- Has Ernst's zoombuttons styling merged in...

![screen shot 2016-12-15 at 11 35 05](https://cloud.githubusercontent.com/assets/7193/21220734/96353a3a-c2ba-11e6-9484-c94be5ad0604.jpg)
