### PR TITLE
[On Hold] fix(omnibox): don't draw stacked-bar-chart when having insufficient data

### DIFF
--- a/app/components/graph/graph-service.js
+++ b/app/components/graph/graph-service.js
@@ -368,9 +368,13 @@ angular.module('lizard-nxt')
         orientation: 'bottom',
         tickFormat: d3.format(".0%") // Custom tickFomat in percentages
       };
-      this._x = createXGraph(this._svg, this.dimensions, labels, options);
 
-      if (data === null) { return; } // We are done here.
+      if (data === null || data.length === 1 && data[0] === null) {
+        // We are done here.
+        return;
+      }
+
+      this._x = createXGraph(this._svg, this.dimensions, labels, options);
 
       // normalize data
       var total = d3.sum(data, function (d) {

--- a/app/components/omnibox/templates/geometry-cards.html
+++ b/app/components/omnibox/templates/geometry-cards.html
@@ -25,7 +25,9 @@
     </defaultpoint>
 
     <div
-      ng-if="geom.geometry.type === 'LineString' && (properties.scale === 'interval' || properties.scale === 'ratio')"
+      ng-if="geom.geometry.type === 'LineString' && (
+        properties.scale === 'interval' || properties.scale === 'ratio'
+      )"
       class="card active card-content">
 
       <graph
@@ -52,6 +54,7 @@
 
     <div
       ng-if="properties.data
+      && !(properties.data.length === 1 && properties.data[0] === null)
       && (geom.geometry.type === 'Polygon' || geom.geometry.type === 'MultiPolygon')
       && properties.slug !== 'rain'"
       class="card active">


### PR DESCRIPTION
This solves two related problems:

1) D3 error: "d is null ... <20 lines stacktrace>" in dev console; D3 was not able to draw the stacked-bar-chart because insufficient data was returned in the API response.

2) D3 crashing while trying to draw the graph resulted in a large empty white space in the omnibox, reserved for a stacked bar chart. This looks (looked) rather crappy.
