### PR TITLE
fix(rain): prevent yAxis label omission => default becomes 'mm'

### DIFF
--- a/app/components/graph/graph-service.js
+++ b/app/components/graph/graph-service.js
@@ -1433,6 +1433,13 @@ angular.module('lizard-nxt')
    * @param  {boolean}      draw on y axis, else x-axis.
    */
   var drawLabel = function (svg, dimensions, label, y) {
+    // Hack-alert: if label === undefined, we assume it to be "mm". We do this
+    // because the only place where this "blank label" bug occurs is when
+    // drawing the barchart for rain, and that requires "mm" as the label on
+    // the yAxis.
+    if (label === undefined) {
+      label = "mm";
+    }
     var width = Graph.prototype._getWidth(dimensions),
         height = Graph.prototype._getHeight(dimensions),
         mv,


### PR DESCRIPTION
Fix for issue: https://github.com/nens/lizard-nxt/issues/2166

NB! A more elaborate fix can be made when having local radar data again, but this will work for the nearby future.