### PR TITLE
Fix(data-service): redo 138f52934d7d671c301d6b34b52698e73dfd2b55 whic…

### DIFF
--- a/app/components/data-menu/services/data-service.js
+++ b/app/components/data-menu/services/data-service.js
@@ -350,26 +350,30 @@ angular.module('data-menu')
           }
 
           promises.push(
-            dataLayer.getData(options).then(function (response) {
-              // async so remove anything obsolete.
-              geo.properties = geo.properties || {};
-              geo.properties[layer.uuid] = geo.properties[layer.uuid] || _.clone(dataLayer);
-              // Replace data and merge everything with existing state of
-              // property.
-              if (response.data) {
-                geo.properties[layer.uuid].data = [];
-                _.merge(geo.properties[layer.uuid], response);
-              } else {
-                geo.properties[layer.uuid].data = response;
-              }
-              if ((!layer.active && layer.uuid in Object.keys(geo.properties))
-                || geo.properties[layer.uuid].data === null) {
+            dataLayer.getData(options).then(
+              function (response) {
+                // async so remove anything obsolete.
+                geo.properties = geo.properties || {};
+                geo.properties[layer.uuid] = geo.properties[layer.uuid] || _.clone(dataLayer);
+                // Replace data and merge everything with existing state of
+                // property.
+                if (response.data) {
+                  geo.properties[layer.uuid].data = [];
+                  _.merge(geo.properties[layer.uuid], response);
+                } else {
+                  geo.properties[layer.uuid].data = response;
+                }
+                if ((!layer.active && layer.uuid in Object.keys(geo.properties))
+                  || geo.properties[layer.uuid].data === null) {
 
-                // Use delete to remove the key and the value and the omnibox
-                // can show a nodata message.
-                delete geo.properties[layer.uuid];
-              }
-            })
+                  // Use delete to remove the key and the value and the omnibox
+                  // can show a nodata message.
+                  delete geo.properties[layer.uuid];
+                }
+              },
+              // Catch rejections, otherwise $.all(promises) is never resolved.
+              _.noop
+            )
           );
         }
       };


### PR DESCRIPTION
…h was lost in a merge

- Fixes nens/lizard-nxt#2060
- Fixes nens/lizard-nxt#2053

Look at the history of [data-service](https://github.com/nens/lizard-client/commits/master/app/components/data-menu/services/data-service.js)

Commit 138f52934d7d671c301d6b34b52698e73dfd2b55 adds this `_.noop` function.
Commit c30c1b4609d55ad9a6be4049e7e7d805da831fd6 comes right after it and changes indentation in the same lines. It does not put `_.noop` back. A classic case of a bogus merge resolve. 