### PR TITLE
chore(bower): Point chromath to nens/chromath

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,7 @@
     "bootstrap": "~3.1.1",
     "bootstrap-datepicker": "~1.6.4",
     "classList.js": "https://github.com/nens/classList.js.git#master",
-    "chromath": "https://github.com/ernstkui/chromath.git#master",
+    "chromath": "https://github.com/nens/chromath.git#master",
     "components-font-awesome": "~4.5.0",
     "d3": "~3.4.11",
     "d3-comparator": "~0.1.0",


### PR DESCRIPTION
instead of ernstkui/chromath. This is a fork because the original repo bears a bower.json file.