### PR TITLE
[DOING] fix(omnibox): overflowing names are truncated

### DIFF
--- a/app/components/legend/templates/legend.html
+++ b/app/components/legend/templates/legend.html
@@ -36,11 +36,13 @@
           class="discrete-legend-datum"
           ng-if="$index < getAmountOfDiscreteCategories(uuid)">
 
-          <div class="discrete-legend-color-rect"
+          <div title="{{ datum.label === -1 ? 'other' : datum.label }}"
+               class="discrete-legend-color-rect"
                ng-style="getColoredRect(datum)">
           </div>
 
           <div class="discrete-legend-label"
+               title="{{ datum.label === -1 ? 'other' : datum.label }}"
                ng-class="{'discrete-legend-label-selected': getDiscreteRasterCategory(uuid) === datum.class,
                           'discrete-legend-label-selectable': rasterIsVectorized(uuid)}">
             {{ datum.label === -1 ? 'other' : (datum.label | truncate: 42) }}

--- a/app/components/legend/templates/legend.html
+++ b/app/components/legend/templates/legend.html
@@ -43,8 +43,9 @@
           <div class="discrete-legend-label"
                ng-class="{'discrete-legend-label-selected': getDiscreteRasterCategory(uuid) === datum.class,
                           'discrete-legend-label-selectable': rasterIsVectorized(uuid)}">
-            {{ datum.label === -1 ? 'other' : datum.label }}
+            {{ datum.label === -1 ? 'other' : (datum.label | truncate: 42) }}
           </div>
+
         </div>
       </div>
     </div>

--- a/app/components/omnibox/directives/db-asset-card-directive.js
+++ b/app/components/omnibox/directives/db-asset-card-directive.js
@@ -26,6 +26,11 @@ angular.module('omnibox')
         });
       };
 
+      scope.getTsLongName = function (uuid) {
+        var metaData = scope.getTsMetaData(uuid);
+        return metaData.location + ',' + metaData.parameter;
+      };
+
       scope.assetHasSurfaceLevel = function () {
         return ('surface_level' in scope.asset);
       };

--- a/app/components/omnibox/templates/db-asset-card.html
+++ b/app/components/omnibox/templates/db-asset-card.html
@@ -62,11 +62,10 @@
 
           <span
             title="{{ getTsMetaData(ts.uuid).location }}, {{ getTsMetaData(ts.uuid).name }}, {{ getTsMetaData(ts.uuid).parameter }}"
-            ng-class="{'text-primary': ts.active}">
+            ng-class="{'text-primary': ts.active}"
+            ng-init="displayName = (getTsLongName(ts.uuid) | truncate: 50)">
 
-            {{ getTsMetaData(ts.uuid).location }},
-            {{ getTsMetaData(ts.uuid).parameter }}
-            &nbsp;
+            {{ displayName }}&nbsp;
 
             <i class="fa relativate-ts-icon"
                ng-class="{ 'fa-check-square': relativeTimeseries.value, 'fa-square': !relativeTimeseries.value }"
@@ -79,8 +78,8 @@
                }}"
                translate>
             </i>
-
           </span>
+
         </div>
 
         <color-picker></color-picker>


### PR DESCRIPTION
This improves/ixes two issues:

1) In the legend, discrete raster labels could get too long; now they get truncated
2) In db context, timeseries names could get too long; now they get truncated.

Fix for: https://github.com/nens/lizard-nxt/issues/2179