### PR TITLE
[ON HOLD] feat(raster animation): rasters can be animated without flickering

### DIFF
--- a/app/components/map/services/raster-map-layer-service.js
+++ b/app/components/map/services/raster-map-layer-service.js
@@ -35,7 +35,21 @@ angular.module('map')
       // frequent images it should be large. When having a very sparse
       // resolution, animation will also move slowly, so there is no need
       // for a big buffer.
-      rasterMapLayer._bufferLength = options.frequency >= 3600000 ? 2 : 6;
+      // rasterMapLayer._bufferLength = options.frequency >= 3600000 ? 2 : 6;
+
+      // We set this once, dynamically (=when first call to rasterMapLayer
+      // .update gets made).
+      rasterMapLayer._bufferLength = undefined;
+
+      rasterMapLayer._setBufferLength = function (timeState) {
+        if (this.slug.indexOf('rain') > -1) {
+          rasterMapLayer._bufferLength = this.frequency >= 3600000 ? 2 : 6;
+        } else {
+          var wantedBufferSize = Math.ceil(
+            (timeState.end - timeState.start) / this.frequency);
+          rasterMapLayer._bufferLength = wantedBufferSize;
+        }
+      };
 
       // Number of rasters currently underway.
       rasterMapLayer._nLoadingRasters = 0;
@@ -55,6 +69,11 @@ angular.module('map')
       );
 
       rasterMapLayer.update = function (map, timeState, options) {
+        if (rasterMapLayer.temporal &&
+            rasterMapLayer._bufferLength === undefined) {
+          this._setBufferLength(timeState);
+        }
+
         // Wms options might be different for current zoom and aggWindow.
         // Redraw when wms parameters are different for temporal or spatial
         // zoom.
@@ -435,11 +454,13 @@ angular.module('map')
        * @param  {int}    currentDate ms from epoch
        */
       rasterMapLayer._animateSyncTime = function (timeState, map, currentDate, wmsOptions) {
+
         var newBounds = rasterMapLayer._getAnimationBounds(map);
 
         if (rasterMapLayer._imageOverlays.length < rasterMapLayer._bufferLength
           || newBounds.getNorth() !== rasterMapLayer._animationBounds.getNorth()
           || newBounds.getWest() !== rasterMapLayer._animationBounds.getWest()) {
+
           rasterMapLayer._animationBounds = newBounds;
 
           // add leaflet layers to fill up the buffer and set imageUrlBase
@@ -468,15 +489,15 @@ angular.module('map')
         }
 
         var currentOverlayIndex = rasterMapLayer._frameLookup[currentDate];
+
         if (currentOverlayIndex === undefined) {
-          // Ran out of buffered frames
+          // alert("Fetch initiated");
+          // Ran out of buffered frames:
           rasterMapLayer._imageOverlays = rasterMapLayer._fetchNewFrames(
             currentDate,
             rasterMapLayer._imageOverlays
           );
-        }
-
-        else {
+        } else {
           rasterMapLayer._progressFrame(currentOverlayIndex, wmsOptions);
           // Done!
         }
@@ -572,7 +593,6 @@ angular.module('map')
        */
       rasterMapLayer._progressFrame = function (currentOverlayIndex, wmsOptions) {
         angular.forEach(rasterMapLayer._frameLookup, function (frameIndex, key) {
-
           if (rasterMapLayer._imageOverlays[frameIndex].options.opacity !== 0
             && frameIndex !== currentOverlayIndex) {
             // Delete the old overlay from the lookup, it is gone.

--- a/app/components/timeline/time-controller.js
+++ b/app/components/timeline/time-controller.js
@@ -86,6 +86,27 @@ angular.module('lizard-nxt')
       syncTimeWrapper(State.temporal);
     });
 
+    //////////////////////////////////////////////
+    // TMP: debugging frame problems (06-02-2017):
+    //////////////////////////////////////////////
+    var oldTime,
+        newTime,
+        diffTime,
+        frameCount = 0; // NB!
+
+    var printTime = function () {
+      var newTime = new Date();
+      if (!oldTime) {
+        diffTime = null;
+      } else {
+        diffTime = newTime - oldTime;
+      }
+      oldTime = newTime;
+    };
+    ////////////////////////////////////////////////
+    // END of debugging tools //////////////////////
+    ////////////////////////////////////////////////
+
     // *
     //  * @description sets the timeStep and minLag on the basis of layergroups and
     //  *              their temporalResolution. The temporal layer with the smallest
@@ -113,11 +134,11 @@ angular.module('lizard-nxt')
             minLag = timeStep / 1200 > 240 ? timeStep / 1200 : 250;
             minLag = minLag > 1000 ? 1000 : minLag;
           }
-
         }
       });
 
       this.animatable = activeTemporalLs;
+
       // Do not continue animating when there is nothing to animate.
       if (!this.animatable) {
         State.temporal.playing  = false;
@@ -154,6 +175,9 @@ angular.module('lizard-nxt')
      * of temporal extent.
      */
     var step =  function () {
+      // frameCount++;
+      // printTime();
+      /////////////////////
       // Make a new step.
       $scope.$apply(function () {
         State.temporal.at += timeStep;


### PR DESCRIPTION
I think the best thing we can do is to rewrite the raster animation part, with a single new constraint:
the temporal extent remains fixed when the animation is playing; if the user wants to change the temporal extent, (s)he needs to first pause the animation. Please discuss @JoepGrispen @gijs @remcogerlich @lexvand 