### PR TITLE
[DONE] fix(searchbar): differentiate between english and dutch

### DIFF
--- a/app/components/omnibox/directives/search-directive.js
+++ b/app/components/omnibox/directives/search-directive.js
@@ -239,6 +239,20 @@ angular.module('omnibox')
     };
 
     /**
+     * Placeholder attr's can not get translated like the rest of the strings
+     * appearing in the DOM. Therefore, a beauti-fool hack:
+     */
+    scope.setSearchBoxPlaceholder = function () {
+      if (window.location.href.indexOf("/nl/") > -1) {
+        // Apparently, we want dutch placeholder:
+        return "Zoek naar plaatsen, or datums (i.e. 23-10-2013)";
+      } else {
+        // Apparently, we want english (default) placeholder:
+        return "Search for places, or dates (i.e. 23-10-2013)";
+      }
+    };
+
+    /**
      * @description removes location model from box content
      */
     var destroySearchResultsModel = function () {

--- a/app/components/omnibox/directives/search-directive.js
+++ b/app/components/omnibox/directives/search-directive.js
@@ -245,7 +245,7 @@ angular.module('omnibox')
     scope.setSearchBoxPlaceholder = function () {
       if (window.location.href.indexOf("/nl/") > -1) {
         // Apparently, we want dutch placeholder:
-        return "Zoek naar plaatsen, or datums (i.e. 23-10-2013)";
+        return "Zoek naar plaatsen, of datums (i.e. 23-10-2013)";
       } else {
         // Apparently, we want english (default) placeholder:
         return "Search for places, or dates (i.e. 23-10-2013)";

--- a/app/components/omnibox/templates/search.html
+++ b/app/components/omnibox/templates/search.html
@@ -17,7 +17,7 @@
         <input
           id="searchboxinput"
           accesskey="s"
-          placeholder="{{ 'Search for places, or dates (i.e. 23-10-2013)' | translate }}"
+          placeholder="{{ setSearchBoxPlaceholder() }}"
           autocomplete="off"
           dir="ltr"
           ng-model="query"


### PR DESCRIPTION
Searchbar text now gets translated OK. Translating the HTML "placeholder" attribute does not play nice with our outsourced translations (@transifex), so an alternative is now in place.

Fix for issue: https://github.com/nens/lizard-nxt/issues/2219