### PR TITLE
[Done] fix(timeseries): fixed downloading timeseries when timeline moves.

### DIFF
--- a/app/components/timeseries/timeseries-directive.js
+++ b/app/components/timeseries/timeseries-directive.js
@@ -103,6 +103,15 @@ angular.module('timeseries')
 
       });
 
+      /**
+       * Get new ts when time changes
+       */
+      scope.$watch('timeState.timelineMoving', function (newValue, oldValue) {
+        if (!newValue && newValue !== oldValue) {
+          TimeseriesService.syncTime().then(getContentForAsset);
+          }
+      });
+
     },
     restrict: 'A',
     templateUrl: 'timeseries/timeseries.html',


### PR DESCRIPTION
Fixes https://github.com/nens/lizard-nxt/issues/2239