### PR TITLE
[DONE] feat(legend): legend can handle style-per-aggWindow-per-zoomLevel (e.…

### DIFF
--- a/app/components/legend/legend-service.js
+++ b/app/components/legend/legend-service.js
@@ -90,12 +90,12 @@ angular.module('legend')
           if (contRasterData.min === null) {
             contRasterData.min = styleMin === undefined
               ? _.first(colormap.data)[0]
-              : parseFloat(styleMin)
+              : parseFloat(styleMin);
           }
           if (contRasterData.max === null) {
             contRasterData.max = styleMax === undefined
               ? _.last(colormap.data)[0]
-              : parseFloat(styleMax)
+              : parseFloat(styleMax);
           }
         }
       }.bind(this));

--- a/app/components/legend/legend-service.js
+++ b/app/components/legend/legend-service.js
@@ -3,6 +3,34 @@ angular.module('legend')
   'DataService', 'UtilService', 'RasterService', 'State', '$q', '$http',
   function (DataService, UtilService, RasterService, State, $q, $http) {
 
+    /* COMMENT CONCERING MIN/MAX FOR CONTINUOUS RASTERS (d.d. 18-04-2017):
+
+    Continuous rasters can now handle the following 4 formats for the "styles"
+    option, as configurable in the Django admin:
+
+    1) "styles": "dem_nl"
+    2) "styles": "dem_nl:[MIN]:[MAX]"
+    3) "styles": {"0":
+                   {"0": "radar-5min",
+                    "3600000": "radar-hour",
+                    "86400000": "radar-day"}
+                  ...
+                 }
+    4) "styles": {"0":
+                   {"0": "radar-5min:[MIN]:[MAX]",
+                    "3600000": "radar-hour:[MIN]:[MAX]",
+                    "86400000": "radar-day:[MIN]:[MAX]"}
+                  ...
+                 }
+
+      In the case (1) and (3), the (normalized) MIN and MAX values used for the
+      legend are retrieved from the colormaps API endpoint, while in case (2)
+      and (4) they are readily available in the frontend.
+
+      TODO: extract all things "styles" related to a sepecrate class!
+     */
+
+
     this.rasterData = {
       continuous: {},
       discrete: {},
@@ -88,14 +116,18 @@ angular.module('legend')
           contRasterData = this.rasterData.continuous[uuid];
           contRasterData.colormap = colormap;
           if (contRasterData.min === null) {
-            contRasterData.min = styleMin === undefined
-              ? _.first(colormap.data)[0]
-              : parseFloat(styleMin);
+            if (styleMin === undefined) {
+              contRasterData.min = _.first(colormap.data)[0];
+            } else {
+              contRasterData.min = parseFloat(styleMin);
+            }
           }
           if (contRasterData.max === null) {
-            contRasterData.max = styleMax === undefined
-              ? _.last(colormap.data)[0]
-              : parseFloat(styleMax);
+            if (styleMax === undefined) {
+              contRasterData.max = _.last(colormap.data)[0];
+            } else {
+              contRasterData.max = parseFloat(styleMax);
+            }
           }
         }
       }.bind(this));

--- a/app/lib/util-service.js
+++ b/app/lib/util-service.js
@@ -1085,6 +1085,12 @@ angular.module('lizard-nxt')
     return closest;
   };
 
+  this.extractStylesString = function (styles, aggWindow) {
+    return typeof styles === typeof {}
+      ? styles[0][aggWindow]
+      : styles;
+  };
+
   /**
     * @description  This function is used to format a raster configs "styles"
     *               value. This should be used for e.g. colormap API calls, where
@@ -1099,13 +1105,11 @@ angular.module('lizard-nxt')
     *
     * @param {string} styles
     */
-  this.extractColormapName = function (styles) {
-    var parts = styles.split(":");
-    if (parts.length > 1) {
-      return parts[0];
-    } else {
-      return styles;
-    }
+  this.extractColormapName = function (stylesString) {
+    var parts = stylesString.split(":");
+    return parts.length > 2
+      ? parts[0]
+      : stylesString;
   };
 
   /**
@@ -1116,19 +1120,16 @@ angular.module('lizard-nxt')
     *
     *               "dem-nl"     => false
     *               "dem-nl:8:9" => true
-    *               "dem-nl:8:"  => true
+    *               "dem-nl:8:"  => false
     *               "abcd"       => false
     *               "abcd:0:23"  => true
     *
     * @param {string} styles
     */
-  this.isCompoundStyles = function (styles) {
-    if (styles) {
-      var parts = styles.split(":");
-      return parts.length === 3;
-    } else {
-      return false;
-    }
+  this.isCompoundStyles = function (stylesString) {
+    return stylesString
+      ? stylesString.split(":").length === 3
+      : false
   };
 
   /*

--- a/app/lib/util-service.js
+++ b/app/lib/util-service.js
@@ -1120,7 +1120,7 @@ angular.module('lizard-nxt')
     *
     *               "dem-nl"     => false
     *               "dem-nl:8:9" => true
-    *               "dem-nl:8:"  => false
+    *               "dem-nl:8:"  => true => THIS SHOULD BE CAUGHT IN DJANGO..
     *               "abcd"       => false
     *               "abcd:0:23"  => true
     *

--- a/app/lib/util-service.js
+++ b/app/lib/util-service.js
@@ -1120,7 +1120,7 @@ angular.module('lizard-nxt')
     *
     *               "dem-nl"     => false
     *               "dem-nl:8:9" => true
-    *               "dem-nl:8:"  => true => THIS SHOULD BE CAUGHT IN DJANGO..
+    *               "dem-nl:8:"  => true => Though this probably not work well.
     *               "abcd"       => false
     *               "abcd:0:23"  => true
     *


### PR DESCRIPTION
…g: rain)

This substitutes the quick fix from this morning: https://github.com/nens/lizard-client/pull/859

Continuous rasters can now handle the following 4 formats for the "styles" option, as configurable in the Django admin:

1) "styles": "dem_nl"
2) "styles": "dem_nl:[MIN]:[MAX]" 
3) "styles": {"0": {"0": "radar-5min", "3600000": "radar-hour", "86400000": "radar-day"} ... }
4) "styles": {"0": {"0": "radar-5min:[MIN]:[MAX]", "3600000": "radar-hour:[MIN]:[MAX]", "86400000": "radar-day:[MIN]:[MAX]"} ... }

In the case (1) and (3), the (normalized) MIN and MAX values used for the legend are retrieved from the colormaps API endpoint, while in case (2) and (4) they are readily available in the front-end.