### PR TITLE
[DOING] feat(dashboard): empty TS can be combined with non-empty TS

### DIFF
--- a/app/components/dashboard/dashboard.html
+++ b/app/components/dashboard/dashboard.html
@@ -7,8 +7,6 @@
 
   <!-- Use track by to keep references to dom elements and prevent redraws -->
   <!-- Store index on dom element for drag and drop functionality -->
-
-
   <div
     ng-if="item.type !== 'empty'"
     ng-repeat="item in dashboard.graphs track by $index"

--- a/app/components/dashboard/dashboard.html
+++ b/app/components/dashboard/dashboard.html
@@ -7,6 +7,8 @@
 
   <!-- Use track by to keep references to dom elements and prevent redraws -->
   <!-- Store index on dom element for drag and drop functionality -->
+
+
   <div
     ng-if="item.type !== 'empty'"
     ng-repeat="item in dashboard.graphs track by $index"

--- a/app/components/graph/graph-service.js
+++ b/app/components/graph/graph-service.js
@@ -1475,7 +1475,7 @@ angular.module('lizard-nxt')
    * @param  {string}       (optional) label, if undefined uupdates current.
    * @param  {boolean}      draw on y axis, else x-axis.
    */
-    var drawLabel = function (svg, dimensions, label, y) {
+  var drawLabel = function (svg, dimensions, label, y) {
     var width = Graph.prototype._getWidth(dimensions),
         height = Graph.prototype._getHeight(dimensions),
         mv,
@@ -1504,9 +1504,20 @@ angular.module('lizard-nxt')
         .attr('y', dimensions.height);
     }
 
-    mv = y
-      ? 0.5 * el.node().getBBox().height + PIXEL_CORRECTION
-      : - 0.5 * el.node().getBBox().height + PIXEL_CORRECTION;
+    try {
+      var h = el.node().getBBox().height;
+      console.log("[!] h =", h);
+      mv = y
+        ? (0.5 * h) + PIXEL_CORRECTION
+        : (-0.5 * h) + PIXEL_CORRECTION;
+
+    } catch (e) {
+      console.log("[E] e =", e);
+      return el;
+    }
+
+    console.log("[dbg] mv =", mv);
+
     el.attr('dy', mv);
     return el;
   };

--- a/app/components/graph/graph-service.js
+++ b/app/components/graph/graph-service.js
@@ -1504,20 +1504,9 @@ angular.module('lizard-nxt')
         .attr('y', dimensions.height);
     }
 
-    try {
-      var h = el.node().getBBox().height;
-      console.log("[!] h =", h);
-      mv = y
-        ? (0.5 * h) + PIXEL_CORRECTION
-        : (-0.5 * h) + PIXEL_CORRECTION;
-
-    } catch (e) {
-      console.log("[E] e =", e);
-      return el;
-    }
-
-    console.log("[dbg] mv =", mv);
-
+    mv = y
+      ? 0.5 * el.node().getBBox().height + PIXEL_CORRECTION
+      : - 0.5 * el.node().getBBox().height + PIXEL_CORRECTION;
     el.attr('dy', mv);
     return el;
   };

--- a/app/components/omnibox/directives/db-cards-directive.js
+++ b/app/components/omnibox/directives/db-cards-directive.js
@@ -137,11 +137,8 @@ angular.module('omnibox')
         }
 
         if (tsEl.active) {
-
           var otherTSInOriginalPlot = _.find(
-
             State.selected.timeseries,
-
             function (_ts) {
               return _ts.active
                 && _ts.order === orderEl

--- a/app/components/timeseries/timeseries-service.js
+++ b/app/components/timeseries/timeseries-service.js
@@ -360,10 +360,6 @@ angular.module('timeseries')
 
         graphTimeseries.data = ts.events;
 
-        // if (_.isEmpty(ts.events)) {
-        //   console.log("re-order:");
-        // }
-
         graphTimeseries.id = ts.uuid;
         graphTimeseries.valueType = ts.value_type;
         graphTimeseries.measureScale = ts.observation_type.scale;

--- a/app/components/timeseries/timeseries-service.js
+++ b/app/components/timeseries/timeseries-service.js
@@ -241,6 +241,14 @@ angular.module('timeseries')
       );
       return asset;
     };
+
+    this.tsHasData = function (uuid) {
+      // NB! This assumes the only form an empty timeseries' data can have is
+      // the empty list:
+      var ts = _.find(this.timeseries, { id: uuid });
+      var data = ts.data;
+      return !(_.isEmpty(data));
+    };
   }
 ]);
 
@@ -351,6 +359,11 @@ angular.module('timeseries')
         var graphTimeseries = angular.copy(graphTimeseriesTemplate);
 
         graphTimeseries.data = ts.events;
+
+        // if (_.isEmpty(ts.events)) {
+        //   console.log("re-order:");
+        // }
+
         graphTimeseries.id = ts.uuid;
         graphTimeseries.valueType = ts.value_type;
         graphTimeseries.measureScale = ts.observation_type.scale;


### PR DESCRIPTION
_There are still a lot of problems with the whole drag-and-drop functionality;_

this PR fixes (i) the disappearance of the target-graph when dragging a source-TS into it which represent the same TS and (ii) when dragging an empty (=no measured values) source-TS into a target-graph only the empty TS' graph dissappears (previously: the filled graph could dissapear, so only the empty graph would show).

I recommended we completely rewrite the drag-and-drop functionality (estimated: 5 days work, inc. thorough testing)