### PR TITLE
[DONE] fix(layermenu): scroll through list using scrollwheel

### DIFF
--- a/app/lib/util-service.js
+++ b/app/lib/util-service.js
@@ -1153,13 +1153,29 @@ angular.module('lizard-nxt')
 
   /*
    * @description This function is called once to make sure that the user can't
-   *              zoom in/out using the mouse's scrollwheel. Take note that this
-   *              does not interfere with the designed functionality of either
-   *              panning nor zooming the timeline nor map.
+   *              zoom in/out using the ctrl key + the mouse's scrollwheel.
+   *              Take note that this does not interfere with the designed
+   *              functionality of either panning nor zooming the timeline nor
+   *              map.
    */
   this.preventMousewheelZoom = function () {
-    var noZoomFn = function (e) { e.preventDefault(); };
-    $('body').bind('mousewheel', noZoomFn); // Chrome/IE
+    var ctrlIsPressed = null;
+    var isCtrlPressed = function () {
+      return ctrlIsPressed;
+    };
+    var noZoomFn = function (e) {
+      if (isCtrlPressed()) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+    };
+    $(document).keydown(function (e) {
+      if (e.keyCode === 17 || e.key === 'Control') { ctrlIsPressed = true; }
+    });
+    $(document).keyup(function (e) {
+      if (e.keyCode === 17 || e.key === 'Control') { ctrlIsPressed = false; }
+    });
+    $('body').bind('mousewheel', noZoomFn); // Chromium/IE
     $('body').bind('DOMMouseScroll', noZoomFn); // Firefox
   };
 }]);


### PR DESCRIPTION
Fix for: https://github.com/nens/lizard-nxt/issues/2299

This PR re-enables scrolling through a long datamenu/omnibox, while still preventing the user from (accidentally) changing the browsers' zoom-level to anything else than 100%. This zoom-level changes would f*ck up D3 graphs (more specifically, the barcharts in the omnibox: https://github.com/nens/lizard-nxt/issues/2193)