### PR TITLE
[DONE] got the pre-calculated GLG/GHG values into omnibox/db graphs

### DIFF
--- a/app/components/omnibox/wanted-attrs-constant.js
+++ b/app/components/omnibox/wanted-attrs-constant.js
@@ -237,7 +237,19 @@ angular.module('omnibox')
         attrName: "litology",
         ngBindValue: "waterchain.litology",
         valueSuffix: ""
-      }
+      },
+      {
+        keyName: gettext("GHG"), // TODO: translation, although only used for Vitens!?
+        attrName: "high_groundwater_level",
+        ngBindValue: "waterchain.high_groundwater_level",
+        valueSuffix: "m (NAP)"
+      },
+      {
+        keyName: gettext("GLG"), // TODO: translation, although only used for Vitens!?
+        attrName: "low_groundwater_level",
+        ngBindValue: "waterchain.low_groundwater_level",
+        valueSuffix: "m (NAP)"
+      },
     ]
   };
 

--- a/app/components/omnibox/wanted-attrs-constant.js
+++ b/app/components/omnibox/wanted-attrs-constant.js
@@ -239,13 +239,15 @@ angular.module('omnibox')
         valueSuffix: ""
       },
       {
-        keyName: gettext("GHG"), // TODO: translation, although only used for Vitens!?
+        // Percentile calculation
+        keyName: gettext("High groundwater level"),
         attrName: "high_groundwater_level",
         ngBindValue: "waterchain.high_groundwater_level",
         valueSuffix: "m (NAP)"
       },
       {
-        keyName: gettext("GLG"), // TODO: translation, although only used for Vitens!?
+        // Percentile calculation
+        keyName: gettext("Low groundwater level"),
         attrName: "low_groundwater_level",
         ngBindValue: "waterchain.low_groundwater_level",
         valueSuffix: "m (NAP)"


### PR DESCRIPTION
To get this working, please make sure the observation_type of the timeseries (for which the GHG/GLG are readily computed (using Roel's new management cmd))) is set to *WNS9040* in the django admin panel.