### PR TITLE
Remco relative to surface level fixes

### DIFF
--- a/app/components/dashboard/dashboard-service.js
+++ b/app/components/dashboard/dashboard-service.js
@@ -30,7 +30,6 @@ angular.module('dashboard')
    * @return {array} graph
    */
   this.buildGraphs = function (graphs, timeseries, assets, geometries) {
-
     graphs = this._setAllContentToNotUpdated(graphs);
 
     timeseries.forEach(function (ts) {

--- a/app/components/graph/chart-container-service.js
+++ b/app/components/graph/chart-container-service.js
@@ -31,6 +31,7 @@ angular.module('lizard-nxt')
     this.keys = chartContent.keys || defaultKeys;
     this.color = chartContent.color || DEFAULT_GREEN;
     this.unit = chartContent.unit;
+    this.reference_frame = chartContent.reference_frame;
     this.thresholds = chartContent.thresholds;
     this.location = chartContent.location;
     this.name = chartContent.name;
@@ -44,6 +45,7 @@ angular.module('lizard-nxt')
     this.data = chartContent.data;
     this.keys = chartContent.keys || defaultKeys;
     this.color = chartContent.color || DEFAULT_GREEN;
+    this.unit = chartContent.unit;
     this.yMaxMin = NxtD3.prototype._maxMin(this.data, this.keys.y);
   };
 

--- a/app/components/omnibox/directives/db-asset-card-directive.js
+++ b/app/components/omnibox/directives/db-asset-card-directive.js
@@ -9,7 +9,7 @@ angular.module('omnibox')
     link: function (scope, element) {
 
       scope.selected = State.selected;
-      scope.relativeTimeSeries = RTSLService.relativeToSurfaceLevel;
+      scope.relativeTimeseries = RTSLService.relativeToSurfaceLevel;
 
       scope.toggleRelativeTimeseries = function () {
         RTSLService.toggle();

--- a/app/components/omnibox/directives/db-asset-card-directive.js
+++ b/app/components/omnibox/directives/db-asset-card-directive.js
@@ -9,15 +9,14 @@ angular.module('omnibox')
       scope.relativeTimeseries = TimeseriesService.relativeTimeseries;
 
       scope.toggleRelativeTimeseries = function () {
-
         var activeBefore = TimeseriesService.relativeTimeseries.value;
         TimeseriesService.relativeTimeseries.value = !activeBefore;
+
+        // This line shouldn't have any effect as relativeTimeseries is already
+        // a reference to that object.
         scope.relativeTimeseries = TimeseriesService.relativeTimeseries;
 
-        var uuidList = _.map(TimeseriesService.timeseries, function (ts) {
-          return ts.id;
-        });
-        TimeseriesService.syncTime(uuidList);
+        TimeseriesService.syncTime();
       };
 
       scope.getTsMetaData = function (uuid) {

--- a/app/components/omnibox/directives/db-asset-card-directive.js
+++ b/app/components/omnibox/directives/db-asset-card-directive.js
@@ -1,16 +1,18 @@
 
 angular.module('omnibox')
-  .directive('dbAssetCard', [ 'State', 'DataService', 'DragService', 'DBCardsService', 'TimeseriesService', 'AssetService',
-    function (State, DataService, DragService, DBCardsService, TimeseriesService, AssetService) {
+       .directive('dbAssetCard', [
+         'State', 'DataService', 'DragService', 'DBCardsService',
+         'TimeseriesService', 'AssetService', 'RelativeToSurfaceLevelService',
+         function (State, DataService, DragService, DBCardsService,
+                   TimeseriesService, AssetService, RTSLService) {
   return {
     link: function (scope, element) {
 
       scope.selected = State.selected;
-      scope.relativeTimeseries = TimeseriesService.relativeTimeseries;
+      scope.relativeTimeSeries = RTSLService.relativeToSurfaceLevel;
 
       scope.toggleRelativeTimeseries = function () {
-        // Note that this is the same object as TimeseriesService.relativeTimeseries
-        scope.relativeTimeseries.value = !scope.relativeTimeseries.value;
+        RTSLService.toggle();
         TimeseriesService.syncTime();
       };
 

--- a/app/components/omnibox/directives/db-asset-card-directive.js
+++ b/app/components/omnibox/directives/db-asset-card-directive.js
@@ -9,13 +9,8 @@ angular.module('omnibox')
       scope.relativeTimeseries = TimeseriesService.relativeTimeseries;
 
       scope.toggleRelativeTimeseries = function () {
-        var activeBefore = TimeseriesService.relativeTimeseries.value;
-        TimeseriesService.relativeTimeseries.value = !activeBefore;
-
-        // This line shouldn't have any effect as relativeTimeseries is already
-        // a reference to that object.
-        scope.relativeTimeseries = TimeseriesService.relativeTimeseries;
-
+        // Note that this is the same object as TimeseriesService.relativeTimeseries
+        scope.relativeTimeseries.value = !scope.relativeTimeseries.value;
         TimeseriesService.syncTime();
       };
 

--- a/app/components/omnibox/templates/db-asset-card.html
+++ b/app/components/omnibox/templates/db-asset-card.html
@@ -72,9 +72,9 @@
                ng-click="toggleRelativeTimeseries(); $event.stopPropagation();"
                ng-if="ts.active && ts.measureScale === 'interval' &&
                  (assetHasSurfaceLevel() || parentAssetHasSurfaceLevel())"
-               title="{{ relativeTimeseries
-                 && 'Deselect to show absolute values for all timeseries'
-                 || 'Select to show all timeseries relative to surface level'
+               title="{{ relativeTimeseries.value ?
+                   'Deselect to show absolute values for all timeseries'
+                 : 'Select to show all timeseries relative to surface level'
                }}"
                translate>
             </i>

--- a/app/components/omnibox/templates/db-asset-card.html
+++ b/app/components/omnibox/templates/db-asset-card.html
@@ -68,7 +68,7 @@
             {{ displayName }}&nbsp;
 
             <i class="fa relativate-ts-icon"
-               ng-class="{ 'fa-check-square': relativeTimeSeries.value, 'fa-square': !relativeTimeseries.value }"
+               ng-class="{ 'fa-check-square': relativeTimeseries.value, 'fa-square': !relativeTimeseries.value }"
                ng-click="toggleRelativeTimeseries(); $event.stopPropagation();"
                ng-if="ts.active && ts.measureScale === 'interval' &&
                  (assetHasSurfaceLevel() || parentAssetHasSurfaceLevel())"

--- a/app/components/omnibox/templates/db-asset-card.html
+++ b/app/components/omnibox/templates/db-asset-card.html
@@ -68,7 +68,7 @@
             {{ displayName }}&nbsp;
 
             <i class="fa relativate-ts-icon"
-               ng-class="{ 'fa-check-square': relativeTimeseries.value, 'fa-square': !relativeTimeseries.value }"
+               ng-class="{ 'fa-check-square': relativeTimeSeries.value, 'fa-square': !relativeTimeseries.value }"
                ng-click="toggleRelativeTimeseries(); $event.stopPropagation();"
                ng-if="ts.active && ts.measureScale === 'interval' &&
                  (assetHasSurfaceLevel() || parentAssetHasSurfaceLevel())"

--- a/app/components/timeseries/timeseries-service.js
+++ b/app/components/timeseries/timeseries-service.js
@@ -286,17 +286,29 @@ angular.module('timeseries')
       }
 
       if (assetOfTs) {
-        var threshold = {value: null, name: ''};
         _.forEach(
           WantedAttributes[assetOfTs.entity_name].rows,
           function (attr) {
-            if (attr.valueSuffix === graphTimeseries.unit) {
+            // Construct a string like "m (NAP)" to compare to valueSuffix, as
+            // the timeseries object has that in two separate values now.
+            var unitAndReference = (
+              graphTimeseries.unit +
+               (graphTimeseries.reference_frame ? ' ('+graphTimeseries.reference_frame+')' : '')
+            );
+
+            if (attr.valueSuffix === unitAndReference) {
+              // This attribute is to be shown in a chart with this unit and reference
               var value = parseFloat(assetOfTs[attr.attrName]);
+
               if (!isNaN(value)) {
-                var name = assetOfTs.name === '' ? '...' : assetOfTs.name;
-                threshold = {
+                var name = assetOfTs.name || '...';
+                var threshold = {
                   value: value,
-                  name: name + ': ' + attr.keyName
+                  name: name + ': ' + attr.keyName,
+                  // These two are added so thresholds can optionally be
+                  // shown relative to surface level.
+                  reference_frame: graphTimeseries.reference_frame,
+                  surface_level: parseFloat(assetOfTs.surface_level)
                 };
                 graphTimeseries.thresholds.push(threshold);
               }

--- a/app/components/timeseries/timeseries-service.js
+++ b/app/components/timeseries/timeseries-service.js
@@ -39,12 +39,12 @@ angular.module('timeseries')
       set: function (timeseries) {
         console.log('State.selected.timeseries:', timeseries);
         _timeseries = timeseries;
-        service.syncTime(timeseries);
+        service.syncTime();
       },
       enumerable: true
     });
 
-    this.syncTime = function (timeseries) {
+    this.syncTime = function () {
       var groupedTimeseries = {temporalBars: [], temporalLines: []};
       _.forEach(State.selected.timeseries, function(ts){
         if(ts.active){


### PR DESCRIPTION
Add a service that stores the 'relative to surface level' global variable; make a function that combines unit and reference taking into account the value of the variable, make sure it used when drawing the Y-axis label and the mouse hover.

Only works for line graphs, don't know if it can be relevant elsewhere.

The 'MV' string (maaiveld) isn't translated, the feature is currently for Vitens only, I don't know what it should be, and don't know how to do translations inside graph-service.

To do: the other part of #2215, namely making the thresholds relative.