### PR TITLE
Add IE meta tag.

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -32,6 +32,7 @@
     <!-- endbuild -->
 
     <meta http-equiv="X-UA-Compatible" content="IE-Edge">
+    <meta name="msapplication-config" content="none">
 
   </head>
 


### PR DESCRIPTION
Sentry captures a lot of "Not Found: /browserconfig.xml" errors. This seems to solve most of them.

https://sentry.io/nens/lizard-nxt-productie/issues/294982680/events/6377818802/

I'll will also add an empty xml add the server:

https://msdn.microsoft.com/browserconfig.xml