### PR TITLE
[DONE] Dirk prevent export modal closing when polling

### DIFF
--- a/app/components/export/export-directive.js
+++ b/app/components/export/export-directive.js
@@ -17,18 +17,16 @@ angular.module('export')
 .directive('exportSelector',
 
 ['$http', 'DataService', 'TimeseriesService', 'notie','gettextCatalog',
- 'State', 'RelativeToSurfaceLevelService', 'user',
+ 'State', 'RelativeToSurfaceLevelService', 'user', 'ExportService',
 
 function ($http, DataService, TimeseriesService, notie, gettextCatalog,
-  State, RTSLService, user) {
+  State, RTSLService, user, ExportService) {
 
   var link = function (scope) {
     // bind the assets with the selected things from the DataService
     scope.assets = DataService.assets;
     scope.isMap = State.context === 'map';
-
     scope.isAuthenticated = user.authenticated;
-    scope.isPolling = false;
 
     var POLL_INTERVAL = 1000;
 
@@ -114,7 +112,7 @@ function ($http, DataService, TimeseriesService, notie, gettextCatalog,
        */
       var pollForFile = function (taskResponseData) {
 
-        scope.isPolling = true;
+        ExportService.setIsPolling(true);
         scope.resultUrl = null;
 
         hideExportButton();
@@ -130,7 +128,7 @@ function ($http, DataService, TimeseriesService, notie, gettextCatalog,
               // Apparently, the task (=exporting timeseries) resulted in a
               // downloadable file: we need to stop polling the server now.
 
-              scope.isPolling = false;
+              ExportService.setIsPolling(false);
               clearInterval(poller);
 
               var resultUrl = response.data.result_url;

--- a/app/components/export/export-service.js
+++ b/app/components/export/export-service.js
@@ -1,0 +1,10 @@
+angular.module('export').service('ExportService', function () {
+
+  return {
+    isPolling: { value: false },
+    setIsPolling: function (newValue) {
+      console.log("[F] setIsPolling; newValue =", newValue);
+      this.isPolling.value = newValue;
+    }
+  }
+});

--- a/app/components/export/export-service.js
+++ b/app/components/export/export-service.js
@@ -3,7 +3,6 @@ angular.module('export').service('ExportService', function () {
   return {
     isPolling: { value: false },
     setIsPolling: function (newValue) {
-      console.log("[F] setIsPolling; newValue =", newValue);
       this.isPolling.value = newValue;
     }
   }

--- a/app/components/ui-utils/modal-base.html
+++ b/app/components/ui-utils/modal-base.html
@@ -4,7 +4,13 @@
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <button type="button" class="close" ng-click="closeModal()" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <button type="button"
+                class="close"
+                ng-click="closeModal()"
+                aria-label="Close"
+                ng-if="mayCloseModal()">
+          <span aria-hidden="true">&times;</span>
+        </button>
         <h4 class="modal-title" translate>
           Export timeseries
         </h4>

--- a/app/components/ui-utils/modal-directive.js
+++ b/app/components/ui-utils/modal-directive.js
@@ -5,8 +5,8 @@
  * For now it always contains the export-selector directive
  */
 
-angular.module('ui-utils').directive('uiModal', [
-  function () {
+angular.module('ui-utils').directive('uiModal', ['ExportService',
+  function (ExportService) {
     var link = function (scope, el) {
       var mode = (scope.active) ? 'show' : 'hide';
       $(el).modal(mode);
@@ -20,6 +20,10 @@ angular.module('ui-utils').directive('uiModal', [
         var mode = (scope.active) ? 'show' : 'hide';
         $(el).modal(mode);
       };
+
+      scope.mayCloseModal = function () {
+        return !ExportService.isPolling.value;
+      }
 
       // ensures there is no conflict between Bootstrap set state and ng internals
       el.on('hide.bs.modal', function (e) {

--- a/app/index.html
+++ b/app/index.html
@@ -223,6 +223,7 @@
     <script src="/components/user-menu/user-menu-directive.js"></script>
 
     <script src="/components/export/export.js"></script>
+    <script src="/components/export/export-service.js"></script>
     <script src="/components/export/export-directive.js"></script>
 
     <script src="/components/ui-utils/ui-utils.js"></script>


### PR DESCRIPTION
This PR solves https://github.com/nens/lizard-nxt/issues/2393: an unauthenticated user can no longer close the modal when the application is still polling for the exported timeseries data.