### PR TITLE
[DONE] Searchbar fixes

### DIFF
--- a/app/components/omnibox/directives/omnibox-directives.js
+++ b/app/components/omnibox/directives/omnibox-directives.js
@@ -19,6 +19,7 @@ angular.module("omnibox")
       };
 
       scope.onFocus = function(item, $event) {
+        console.log("onFocus!");
         item.selected = "selected";
         if (item.hasOwnProperty('formatted_address')) {
           scope.zoomToSpatialResultWithoutClearingSeach(item);
@@ -29,6 +30,7 @@ angular.module("omnibox")
       };
 
       scope.selectItem = function($event, result) {
+        console.log("selectdItem");
         var e = $event;
         switch (e.keyCode) {
           case KeyCodes.RETURNKEY:

--- a/app/components/omnibox/directives/omnibox-directives.js
+++ b/app/components/omnibox/directives/omnibox-directives.js
@@ -19,7 +19,6 @@ angular.module("omnibox")
       };
 
       scope.onFocus = function(item, $event) {
-        console.log("onFocus!");
         item.selected = "selected";
         if (item.hasOwnProperty('formatted_address')) {
           scope.zoomToSpatialResultWithoutClearingSeach(item);
@@ -30,7 +29,6 @@ angular.module("omnibox")
       };
 
       scope.selectItem = function($event, result, spatialOrSearchMode) {
-        console.log("selectItem");
         var e = $event;
         switch (e.keyCode) {
           case KeyCodes.RETURNKEY:

--- a/app/components/omnibox/directives/omnibox-directives.js
+++ b/app/components/omnibox/directives/omnibox-directives.js
@@ -29,39 +29,57 @@ angular.module("omnibox")
         }
       };
 
-      scope.selectItem = function($event, result) {
-        console.log("selectdItem");
+      scope.selectItem = function($event, result, spatialOrSearchMode) {
+        console.log("selectItem");
         var e = $event;
         switch (e.keyCode) {
           case KeyCodes.RETURNKEY:
-            scope.zoomToSearchResult(result);
-            break;
+            if (spatialOrSearchMode === 'spatial') {
+              scope.zoomToSpatialResult(result);
+            } else {
+              scope.zoomToSearchResult(result);
+            }
         }
       };
 
       scope.onKeydown = function($event) {
         var e = $event;
         var $target = $(e.target);
-        var nextTab;
+        var tabIncrement;
         switch (e.keyCode) {
-            case KeyCodes.ESC:
-                $target.blur();
-                scope.cleanInputAndResults();
-                break;
-            case KeyCodes.UPARROW:
-                nextTab = - 1;
-                break;
-            case KeyCodes.DOWNARROW:
-                nextTab = 1;
-                break;
+          case KeyCodes.ESC:
+            $target.blur();
+            scope.cleanInputAndResults();
+            return;
+          case KeyCodes.UPARROW:
+            tabIncrement = -1;
+            break;
+          case KeyCodes.DOWNARROW:
+            tabIncrement = 1;
+            break
+          default:
+            return
         }
-        if (nextTab !== undefined) {
-            // Do this outside the current $digest cycle:
-            // focus the next element by tabindex
-           $timeout(function() {
-             $('[tabindex=' + (parseInt($target.attr('tabindex')) + nextTab) + ']').focus();
-           });
+
+        var resultCount = 0;
+        if (scope.omnibox.searchResults.spatial) {
+          resultCount += scope.omnibox.searchResults.spatial.length;
         }
+        if (scope.omnibox.searchResults.api) {
+          resultCount += scope.omnibox.searchResults.api.length;
+        }
+        if (scope.omnibox.searchResults.temporal) {
+          resultCount += scope.omnibox.searchResults.temporal.length
+        }
+
+        var newTabIndex = parseInt($target.attr('tabindex')) + tabIncrement;
+        if (newTabIndex > resultCount) {
+          newTabIndex = 1
+        } else if (newTabIndex < 1) {
+          newTabIndex = resultCount
+        }
+
+        $timeout(function() { $('[tabindex=' + newTabIndex + ']').focus() });
       };
 
       scope.showAnnotations = function () {

--- a/app/components/omnibox/directives/search-directive.js
+++ b/app/components/omnibox/directives/search-directive.js
@@ -98,7 +98,6 @@ angular.module('omnibox')
      * @param {object} one search result.
      */
     scope.zoomToSearchResult = function (result) {
-      console.log("[F] zoomToSearchResult; arg result = " + JSON.stringify(result));
       State = SearchService.zoomToSearchResult(result, State);
       scope.cleanInputAndResults();
     };
@@ -108,7 +107,6 @@ angular.module('omnibox')
      * @param {object} one search result.
      */
     scope.zoomToSearchResultWithoutClearingSearch = function (result) {
-      console.log("[F] zoomToSearchResultWithoutClearingSearch");
       State = SearchService.zoomToSearchResultWithoutSelecting(result, State);
     };
 
@@ -117,7 +115,6 @@ angular.module('omnibox')
      * @param {object} one search result.
      */
     scope.zoomToSpatialResult = function (result) {
-      console.log("[F] zoomToSpatialResult");
       State = SearchService.zoomToGoogleGeocoderResult(result, State);
       scope.cleanInputAndResults();
     };
@@ -127,7 +124,6 @@ angular.module('omnibox')
      * @param {object} one search result.
      */
     scope.zoomToSpatialResultWithoutClearingSeach = function (result) {
-      console.log("[F] zoomToSpatialResultWithoutClearingSearch");
       State = SearchService.zoomToGoogleGeocoderResult(result, State);
     };
 
@@ -138,18 +134,12 @@ angular.module('omnibox')
      *                              duration.
      */
     scope.zoomToTemporalResult = function(m) {
-      console.log("[F] zoomToTemporalResult");
       scope.omnibox.searchResults = {};
       scope.query = "";
       State.temporal.start = m.valueOf();
       State.temporal.end = m.valueOf() + m.nxtInterval.valueOf();
       UtilService.announceMovedTimeline(State);
     };
-
-
-    var prevKey; // stores the previously pressed key.
-    var prevKeyTimeout; // resets the key after TIMEOUT.
-    var TIMEOUT = 300; // 300 ms
 
     /**
      * @description event handler for key presses.
@@ -158,9 +148,6 @@ angular.module('omnibox')
      * 13 refers to the RETURN key.
      */
     scope.searchKeyPress = function ($event) {
-      console.log("[F] searchKeyPress");
-      clearTimeout(prevKeyTimeout);
-
 
       if ($event.target.id === "searchboxinput") {
         // Intercept keyPresses *within* searchbox,do xor prevent animation
@@ -176,7 +163,6 @@ angular.module('omnibox')
         }
 
         else if ($event.which === KEYPRESS.ENTER) {
-          console.log('KEYPRESS.ENTER')
           var results = scope.omnibox.searchResults;
           if (results.temporal || results.spatial || results.api) {
             if (results.temporal) {

--- a/app/components/omnibox/directives/search-directive.js
+++ b/app/components/omnibox/directives/search-directive.js
@@ -78,28 +78,38 @@ angular.module('omnibox')
     scope.mayCleanInputAndResults = function () {
       return scope.query || (
         scope.omnibox &&
-        scope.omnibox.searchResults &&
-        scope.omnibox.searchResults.spatial &&
-        scope.omnibox.searchResults.spatial.length > 0
+        scope.omnibox.searchResults && (
+          (
+            scope.omnibox.searchResults.spatial &&
+            scope.omnibox.searchResults.spatial.length
+          ) || (
+            scope.omnibox.searchResults.api &&
+            scope.omnibox.searchResults.api.length
+          ) || (
+            scope.omnibox.searchResults.temporal &&
+            scope.omnibox.searchResults.temporal.length
+          )
+        )
       );
     }
-
-    /**
-     * @description zooms to search resulit without clearing search or selecting the item.
-     * @param {object} one search result.
-     */
-    scope.zoomToSearchResultWithoutClearingSearch = function (result) {
-      State = SearchService.zoomToSearchResultWithoutSelecting(result, State);
-    };
 
     /**
      * @description zooms to search resulit
      * @param {object} one search result.
      */
     scope.zoomToSearchResult = function (result) {
-      scope.omnibox.searchResults = {};
-      scope.query = "";
+      console.log("[F] zoomToSearchResult; arg result = " + JSON.stringify(result));
       State = SearchService.zoomToSearchResult(result, State);
+      scope.cleanInputAndResults();
+    };
+
+        /**
+     * @description zooms to search result without clearing search or selecting the item.
+     * @param {object} one search result.
+     */
+    scope.zoomToSearchResultWithoutClearingSearch = function (result) {
+      console.log("[F] zoomToSearchResultWithoutClearingSearch");
+      State = SearchService.zoomToSearchResultWithoutSelecting(result, State);
     };
 
     /**
@@ -107,9 +117,9 @@ angular.module('omnibox')
      * @param {object} one search result.
      */
     scope.zoomToSpatialResult = function (result) {
-      scope.omnibox.searchResults = {};
-      scope.query = "";
+      console.log("[F] zoomToSpatialResult");
       State = SearchService.zoomToGoogleGeocoderResult(result, State);
+      scope.cleanInputAndResults();
     };
 
     /**
@@ -117,6 +127,7 @@ angular.module('omnibox')
      * @param {object} one search result.
      */
     scope.zoomToSpatialResultWithoutClearingSeach = function (result) {
+      console.log("[F] zoomToSpatialResultWithoutClearingSearch");
       State = SearchService.zoomToGoogleGeocoderResult(result, State);
     };
 
@@ -127,6 +138,7 @@ angular.module('omnibox')
      *                              duration.
      */
     scope.zoomToTemporalResult = function(m) {
+      console.log("[F] zoomToTemporalResult");
       scope.omnibox.searchResults = {};
       scope.query = "";
       State.temporal.start = m.valueOf();
@@ -146,6 +158,7 @@ angular.module('omnibox')
      * 13 refers to the RETURN key.
      */
     scope.searchKeyPress = function ($event) {
+      console.log("[F] searchKeyPress");
       clearTimeout(prevKeyTimeout);
 
 
@@ -163,23 +176,17 @@ angular.module('omnibox')
         }
 
         else if ($event.which === KEYPRESS.ENTER) {
+          console.log('KEYPRESS.ENTER')
           var results = scope.omnibox.searchResults;
           if (results.temporal || results.spatial || results.api) {
             if (results.temporal) {
-              scope.zoomToTemporalResult(
-                scope.omnibox.searchResults.temporal
-              );
+              scope.zoomToTemporalResult(results.temporal);
+            } else if (results.spatial) {
+              scope.zoomToSpatialResult(results.spatial[0]);
+            } else if (results.api) {
+              scope.zoomToSearchResult(results.api[0]);
             }
-            else if (results.api) {
-              scope.zoomToSearchResult(
-                scope.omnibox.searchResults.api[0]
-              );
-            }
-            else if (results.spatial) {
-              scope.zoomToSpatialResult(
-                scope.omnibox.searchResults.spatial[0]
-              );
-            }
+
             scope.cleanInputAndResults();
           }
         }

--- a/app/components/omnibox/services/search-service.js
+++ b/app/components/omnibox/services/search-service.js
@@ -134,11 +134,14 @@ angular.module('omnibox')
      *
      * @param  {object} result google geocoder result.
      */
-    this.zoomToGoogleGeocoderResult = function (result, state) {
+    this.zoomToGoogleGeocoderResult = function (result, state, callback) {
       state.spatial.bounds = LeafletService.latLngBounds(
         LeafletService.latLng(result.geometry.viewport.southwest),
         LeafletService.latLng(result.geometry.viewport.northeast)
       );
+      if (callback) {
+        callback()
+      }
       return state;
     };
 

--- a/app/components/omnibox/services/search-service.js
+++ b/app/components/omnibox/services/search-service.js
@@ -134,14 +134,11 @@ angular.module('omnibox')
      *
      * @param  {object} result google geocoder result.
      */
-    this.zoomToGoogleGeocoderResult = function (result, state, callback) {
+    this.zoomToGoogleGeocoderResult = function (result, state) {
       state.spatial.bounds = LeafletService.latLngBounds(
         LeafletService.latLng(result.geometry.viewport.southwest),
         LeafletService.latLng(result.geometry.viewport.northeast)
       );
-      if (callback) {
-        callback()
-      }
       return state;
     };
 

--- a/app/components/omnibox/templates/search-results.html
+++ b/app/components/omnibox/templates/search-results.html
@@ -25,6 +25,7 @@
         ng-repeat="result in omnibox.searchResults.spatial"
         tabindex="{{ $index + 1 }}"
         ng-focus="onFocus(result)"
+        ng-keydown="selectItem($event, result, 'spatial')"
         class="cluster location">
         <i class="fa fa-location-arrow">&nbsp;</i>
         <a ng-click="zoomToSpatialResult(result)"
@@ -43,7 +44,7 @@
         ng-repeat="result in omnibox.searchResults.api"
         tabindex="{{ $index + omnibox.searchResults.spatial.length + 1 }}"
         ng-focus="onFocus(result)"
-        ng-keydown="selectItem($event, result)"
+        ng-keydown="selectItem($event, result, 'search')"
         class="cluster location">
         <a ng-click="zoomToSearchResult(result)"
           href="">

--- a/app/components/omnibox/templates/search-results.html
+++ b/app/components/omnibox/templates/search-results.html
@@ -44,7 +44,7 @@
         ng-repeat="result in omnibox.searchResults.api"
         tabindex="{{ $index + omnibox.searchResults.spatial.length + 1 }}"
         ng-focus="onFocus(result)"
-        ng-keydown="selectItem($event, result, 'search')"
+        ng-keydown="selectItem($event, result)"
         class="cluster location">
         <a ng-click="zoomToSearchResult(result)"
           href="">

--- a/app/components/omnibox/templates/search-results.html
+++ b/app/components/omnibox/templates/search-results.html
@@ -4,6 +4,19 @@
        ng-keydown="onKeydown($event)"
        ng-focus="onFocus(item)">
 
+    <h3 ng-if="omnibox.searchResults.temporal" translate>Time</h3>
+    <div
+      ng-if="omnibox.searchResults.temporal"
+      tabindex="1000"
+      class="cluster location">
+      <a ng-click="zoomToTemporalResult(omnibox.searchResults.temporal)"
+        class="pointer clickable">
+        <span>{{ omnibox.searchResults.temporal.format(
+          omnibox.searchResults.temporal.nxtFormatString
+        ) }}</span>
+      </a>
+    </div>
+
     <h3 ng-if="omnibox.searchResults.spatial.length > 0">
       <span translate>Locations</span>&nbsp;({{ omnibox.searchResults.spatial.length }})
     </h3>
@@ -40,19 +53,6 @@
         </a>
       </li>
     </ul>
-
-    <h3 ng-if="omnibox.searchResults.temporal" translate>Time</h3>
-  	<div
-  		ng-if="omnibox.searchResults.temporal"
-      tabindex="1000"
-  		class="cluster location">
-  	  <a ng-click="zoomToTemporalResult(omnibox.searchResults.temporal)"
-  	    class="pointer clickable">
-  	    <span>{{ omnibox.searchResults.temporal.format(
-  	    	omnibox.searchResults.temporal.nxtFormatString
-  	    ) }}</span>
-  	  </a>
-  	</div>
 
   </div>
 


### PR DESCRIPTION
In this PR:

1) Result categories are ordered differently in omnibox (https://github.com/nens/lizard-nxt/issues/2213)
2) Hitting enter when several categories are shown in results takes you to the first spatial result (e.g. _city of Amsterdam_) instead of the first of the found assets (e.g. _RWZI Amsterdam-west_).
3) Close/clear search results after selecting one of the results
4) After selecting a location (instead of asset) with the arrow keys, you can hit enter to finalize selecting an item from the displayed results. NB! This already worked for assets
5) User can iterate through results with keyboard up-/down arrows without problems at first/last item
