### PR TITLE
[DOING] Prevent unneccesary fn calls for metaData

### DIFF
--- a/app/components/omnibox/directives/db-asset-card-directive.js
+++ b/app/components/omnibox/directives/db-asset-card-directive.js
@@ -20,7 +20,10 @@ angular.module('omnibox').directive('dbAssetCard', [
     UtilService
   ) {
     return {
+
       link: function (scope, element, attrs) {
+
+        scope.selectionsMetaData = {};
 
         scope.colorPickersSettings = DBCardsService.colorPickersSettings;
         scope.openColorPicker = DBCardsService.openColorPicker;
@@ -49,8 +52,15 @@ angular.module('omnibox').directive('dbAssetCard', [
         };
 
         scope.state = State;
-        scope.getSelectionMetaData = SelectionService.getMetaDataFunction(
-          scope.asset);
+
+        scope.getSelectionMetaData = function (selection) {
+          if (!this.selectionsMetaData[selection.uuid]) {
+            this.selectionsMetaData[selection.uuid] =
+               SelectionService.getMetaDataFunction(scope.asset)(selection);
+          }
+          return this.selectionsMetaData[selection.uuid];
+        }
+
         scope.toggleSelection = SelectionService.toggle;
 
         scope.getTsDisplayName = function (selection) {

--- a/app/components/omnibox/directives/db-geometry-card-directive.js
+++ b/app/components/omnibox/directives/db-geometry-card-directive.js
@@ -17,13 +17,19 @@ angular.module('omnibox')
 
         scope.state = State;
         scope.noData = true;
+        scope.selectionsMetaData = {};
 
         scope.colorPickersSettings = DBCardsService.colorPickersSettings;
         scope.openColorPicker = DBCardsService.openColorPicker;
         scope.closeColorPicker = DBCardsService.closeColorPicker;
 
-        scope.getSelectionMetaData = SelectionService.getMetaDataFunction(
-          scope.geom);
+        scope.getSelectionMetaData = function (selection) {
+          if (!this.selectionsMetaData[selection.uuid]) {
+            this.selectionsMetaData[selection.uuid] =
+               SelectionService.getMetaDataFunction(scope.asset)(selection);
+          }
+          return this.selectionsMetaData[selection.uuid];
+        }
 
         // Make sure all event series data etc gets updated on geo.
         DataService.getGeomData(scope.geom).then(function (geo) {


### PR DESCRIPTION
We cache the metadata results that are gotten via the selections-service so no unneccesary fn calls are made to the selection-service. In the current master branch: every iteration of the Angular digest loop results in an attempt to fix _new_ metadata for selections. This is kinda stupid since this metadata is static.