### PR TITLE
[DONE] Changed relative path for img

### DIFF
--- a/app/components/timeseries/timeseries.html
+++ b/app/components/timeseries/timeseries.html
@@ -4,7 +4,7 @@
     <div class="timeseries-header-container">
 
       <i class="omnibox-ts-icon">
-        <img src="../../images/ts-icon-gijs.png" width="24" height="24">
+        <img src="images/ts-icon-gijs.png" width="24" height="24">
       </i>
 
       <select


### PR DESCRIPTION
This is the way path is set for _favicon.png_, which works both locally and remote. The previous path for the new TS icon is read correct in dev env, but not in staging env.