### PR TITLE
[DONE] Zoom-to-the-magic now also works for img timeseries

### DIFF
--- a/app/components/timeseries/timeseries-service.js
+++ b/app/components/timeseries/timeseries-service.js
@@ -272,15 +272,6 @@ angular.module('timeseries').service("TimeseriesService", [
 
 
     this.zoomToInterval = function (value_type, intervalText) {
-      // return early - if the timeseries consists of images
-      if (value_type === 'image') {
-        notie.alert(3,
-          gettextCatalog.getString(
-            "Timeseries with images cannot be zoomed to."
-          )
-        );
-        return;
-      }
 
       var now = (new Date()).getTime();
       var start, end, intervalMs;


### PR DESCRIPTION
No longer prevent zoom-to-the-magic for timeseries with type "image".

_Blind-folded fix_ : I don't have data for actually testing this