### PR TITLE
[DOING] Dirk various ctx switching issues

### DIFF
--- a/app/components/dashboard/dashboard-service.js
+++ b/app/components/dashboard/dashboard-service.js
@@ -72,15 +72,19 @@ function (EventAggregateService,  State,  ChartCompositionService) {
       var selection = (findSelection('timeseries', ts.id)());
       if (selection && selection.active) {
         var order = ChartCompositionService.getChartIndexForSelection(selection.uuid);
-
         ts.updated = true;
         ts.color = selection.color;
         ts.order = order;
         if (graphs[order]) {
           // Check if timeseries is already in the plot, if so replace data.
 
-          var partOfContent =_.find(graphs[selection.order].content,
-                                    function (c) { return c.id === ts.id; });
+          // This line contains an terror-error?
+          ////////////////////////////////////////////////////////////////////
+          // var partOfContent =_.find(graphs[selection.order].content,
+          //                           function (c) { return c.id === ts.id; });
+
+          var partOfContent =_.find(graphs[order].content, { id: ts.id });
+
           if (partOfContent) {
             partOfContent.data = ts.data;
             partOfContent.color = selection.color;

--- a/app/components/data-menu/services/asset-service.js
+++ b/app/components/data-menu/services/asset-service.js
@@ -19,7 +19,9 @@ angular.module('data-menu')
 
           if (timeseriesInAsset || selection.asset === asset.entity_name + "$" + asset.id) {
             // Remove
-            ChartCompositionService.removeSelection(selection.uuid);
+            if (State.context === 'dashboard') {
+              ChartCompositionService.removeSelection(selection.uuid);
+            }
           } else {
             // Keep
             keepSelections.push(selection);

--- a/app/components/data-menu/services/asset-service.js
+++ b/app/components/data-menu/services/asset-service.js
@@ -19,9 +19,7 @@ angular.module('data-menu')
 
           if (timeseriesInAsset || selection.asset === asset.entity_name + "$" + asset.id) {
             // Remove
-            if (State.context === 'dashboard') {
-              ChartCompositionService.removeSelection(selection.uuid);
-            }
+            ChartCompositionService.removeSelection(selection.uuid);
           } else {
             // Keep
             keepSelections.push(selection);

--- a/app/components/data-menu/services/asset-service.js
+++ b/app/components/data-menu/services/asset-service.js
@@ -7,6 +7,27 @@ angular.module('data-menu')
 
       this.NESTED_ASSET_PREFIXES = ['pump', 'filter', 'monitoring_well'];
 
+      var removeAssetSelections = function (asset) {
+        var keepSelections = [];
+
+        for (var i = 0; i < State.selections.length; i++) {
+          var selection = State.selections[i];
+
+          var timeseriesInAsset = (asset.timeseries || []).map(
+            function (ts) { return ts.uuid; }
+          ).indexOf(selection.timeseries) !== -1;
+
+          if (timeseriesInAsset || selection.asset === asset.entity_name + "$" + asset.id) {
+            // Remove
+            ChartCompositionService.removeSelection(selection.uuid);
+          } else {
+            // Keep
+            keepSelections.push(selection);
+          }
+        }
+        State.selections = keepSelections;
+      };
+
       /**
        * @param {string} entity - name of the entity
        * @param {string} id -  id of the enitity
@@ -35,6 +56,9 @@ angular.module('data-menu')
         return currentAssets.filter(function (asset) {
           var assetId = asset.entity_name + '$' + asset.id;
           var keep = selectedAssets.indexOf(assetId) !== -1;
+          if (!keep) {
+            removeAssetSelections(asset);
+          }
           return keep;
         });
       };

--- a/app/components/data-menu/services/data-service.js
+++ b/app/components/data-menu/services/data-service.js
@@ -21,12 +21,13 @@ angular.module('data-menu')
     'AssetService',
     'LayerAdderService',
     'State',
-
+    'ChartCompositionService',
     function (
       $q,
       AssetService,
       LayerAdderService,
-      State
+      State,
+      ChartCompositionService
     ) {
 
       var instance = this;

--- a/app/components/graph/graph-service.js
+++ b/app/components/graph/graph-service.js
@@ -1506,8 +1506,8 @@ angular.module('lizard-nxt')
         .attr('x1', 0)
         .attr('x2', x2);
       g.append('line')
-        .attr('y1', height)
-        .attr('y2', y2)
+        .attr('y1', height || 0)
+        .attr('y2', y2 || 0)
         .attr('x1', x2)
         .attr('x2', x2);
 

--- a/app/components/graph/graph-service.js
+++ b/app/components/graph/graph-service.js
@@ -270,6 +270,7 @@ angular.module('lizard-nxt')
     graph._activeUnit = content.unit;
 
     var data = content.data;
+
     var keys = content.keys;
     var labels = { x: content.xLabel, y: content.unit };
     var originalKey = keys.y;
@@ -1068,6 +1069,8 @@ angular.module('lizard-nxt')
      */
   var drawVerticalRects = function (svg, dimensions, xy, keys, data, duration,
                                     xDomain, activeUnit, color) {
+
+    if (data.data === null) { return; }
 
     var width = Graph.prototype._getWidth(dimensions),
         height = Graph.prototype._getHeight(dimensions),

--- a/app/components/graph/graph-service.js
+++ b/app/components/graph/graph-service.js
@@ -1761,7 +1761,9 @@ angular.module('lizard-nxt')
         .attr('cy', function (d, i) {
           var box = label.node().getBBox();
           return -(box.x + box.width) - PADDING - i * PADDING;
-        });
+        })
+        .append('title')
+        .text(activeCharts.length + " active chart(s) for current y-axis");
 
       circles
         .transition()
@@ -1773,7 +1775,13 @@ angular.module('lizard-nxt')
         .attr('cy', function (d, i) {
           var box = label.node().getBBox();
           return -(box.x + box.width) - PADDING - i * PADDING;
-        });
+        })
+        .selectAll('title')
+        .text(activeCharts.length + " active chart(s) for current y-axis");
+
+      circles.exit()
+        .selectAll('title')
+        .text(activeCharts.length + " active chart(s) for current y-axis");
 
       circles.exit()
         .transition()

--- a/app/components/omnibox/directives/close-card-directive.js
+++ b/app/components/omnibox/directives/close-card-directive.js
@@ -12,10 +12,12 @@ angular.module('omnibox')
 .directive('closeCard', [
   'State',
   'DataService',
+  'getNestedAssets',
   'TimeseriesService',
-  function (State, DataService, TimeseriesService) {
+  function (State, DataService, getNestedAssets, TimeseriesService) {
 
     var link = function (scope, element, attrs) {
+
 
       /**
        * Removes asset from global State.
@@ -26,7 +28,17 @@ angular.module('omnibox')
         if (scope.geometry) {
           State.geometries.removeGeometry(scope.geometry);
         } else if (scope.asset) {
+
           var assetId = scope.asset.entity_name + '$' + scope.asset.id;
+
+          getNestedAssets(scope.asset).forEach(function (asset) {
+            var assetId = asset.entity_name + '$' + asset.id;
+            var i = State.assets.indexOf(assetId);
+            if (i !== -1) {
+              State.assets.removeAsset(assetId);
+            }
+          });
+
           // Remove the asset from the selection.
           var selectedAssets = State.assets;
           if (selectedAssets.indexOf(assetId) >= 0) {

--- a/app/components/omnibox/directives/close-card-directive.js
+++ b/app/components/omnibox/directives/close-card-directive.js
@@ -27,10 +27,12 @@ angular.module('omnibox')
       scope.rmAssetOrGeometry = function () {
         if (scope.geometry) {
           State.geometries.removeGeometry(scope.geometry);
+          // TODO: update composedCharts!
         } else if (scope.asset) {
 
           var assetId = scope.asset.entity_name + '$' + scope.asset.id;
 
+          // Remove the nested assets (for local scope.asset)
           getNestedAssets(scope.asset).forEach(function (asset) {
             var assetId = asset.entity_name + '$' + asset.id;
             var i = State.assets.indexOf(assetId);
@@ -39,7 +41,7 @@ angular.module('omnibox')
             }
           });
 
-          // Remove the asset from the selection.
+          // Remove the asset itself (for local scope.asset)
           var selectedAssets = State.assets;
           if (selectedAssets.indexOf(assetId) >= 0) {
             selectedAssets.removeAsset(assetId);

--- a/app/components/omnibox/directives/close-card-directive.js
+++ b/app/components/omnibox/directives/close-card-directive.js
@@ -46,7 +46,6 @@ angular.module('omnibox')
           if (selectedAssets.indexOf(assetId) >= 0) {
             selectedAssets.removeAsset(assetId);
           }
-
         }
       };
 

--- a/app/components/omnibox/directives/db-cards-directive.js
+++ b/app/components/omnibox/directives/db-cards-directive.js
@@ -67,7 +67,11 @@ angular.module('omnibox')
       };
 
       scope.countRasters = function (geom) {
-        return Object.keys(geom.properties).length;
+        var temporalProps = _.filter(
+          Object.values(geom.properties),
+          { temporal: true }
+        );
+        return temporalProps.length;
       };
 
       /**

--- a/app/components/omnibox/directives/db-cards-directive.js
+++ b/app/components/omnibox/directives/db-cards-directive.js
@@ -11,6 +11,7 @@ angular.module('omnibox')
     'DBCardsService',
     'ChartCompositionService',
     '$timeout',
+    'DataService',
     function (
       State,
       SelectionService,
@@ -21,7 +22,8 @@ angular.module('omnibox')
       TimeseriesService,
       DBCardsService,
       ChartCompositionService,
-      $timeout) {
+      $timeout,
+      DataService) {
   return {
     link: function (scope, element) {
 
@@ -202,6 +204,22 @@ angular.module('omnibox')
         // Remove drag element.
         el.parentNode.removeChild(el);
       });
+
+      scope.mustShowGeomCard = function (geom) {
+        var activeRasters = _.filter(State.layers, function (layer) {
+          return layer.active && layer.type === "raster";
+        });
+        var activeTemporalRasterCount = 0;
+        DataService.dataLayers.forEach(function (dataLayer) {
+          if (dataLayer.temporal) {
+            var activeTemporalraster = _.find(activeRasters, { uuid: dataLayer.uuid });
+            if (activeTemporalraster) {
+              activeTemporalRasterCount += 1;
+            }
+          }
+        });
+        return activeTemporalRasterCount !== 0;
+      };
 
       scope.$on('$destroy', function () {
         DragService.destroy();

--- a/app/components/omnibox/directives/db-geometry-card-directive.js
+++ b/app/components/omnibox/directives/db-geometry-card-directive.js
@@ -71,21 +71,7 @@ angular.module('omnibox')
 
         scope.toggleSelection = SelectionService.toggle;
 
-        scope.$on('$destroy', function () {
-          _.forEach(scope.geom.properties, function (property, uuid) {
-            var selection = _.find(State.selections, function(s) {
-              return s.geom === scope.geom.geometry.coordinates.toString()
-                && s.raster === uuid;
-            });
-            if (selection) {
-              selection.active = true;
-              scope.toggleSelection(selection);
-            }
-          });
-        });
-
         DragService.addDraggableContainer(element.find('#drag-container'));
-
       },
       restrict: 'E',
       scope: {

--- a/app/components/omnibox/directives/db-nested-asset-directive.js
+++ b/app/components/omnibox/directives/db-nested-asset-directive.js
@@ -27,19 +27,7 @@ angular.module('omnibox')
           return asset;
         });
       });
-
-      scope.$on('$destroy', function () {
-        nestedAssets.forEach(function (asset) {
-          var assetId = asset.entity_name + '$' + asset.id;
-          var i = State.assets.indexOf(assetId);
-          if (i !== -1) {
-            State.assets.removeAsset(assetId);
-          }
-        });
-      });
-
     };
-
 
     return {
       link: link,

--- a/app/components/omnibox/directives/omnibox-directives.js
+++ b/app/components/omnibox/directives/omnibox-directives.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module("omnibox")
-.directive("omnibox", ['$window', '$document', 'State', 'user', '$timeout', 'TimeseriesService', 'RelativeToSurfaceLevelService', 'ChartCompositionService',
-  function ($window, $document, State, user, $timeout, TimeseriesService, RTSLService, ChartCompositionService) { return {
+.directive("omnibox", ['$window', '$document', 'State', 'user', '$timeout', 'TimeseriesService', 'RelativeToSurfaceLevelService', 'ChartCompositionService', 'AssetService',
+  function ($window, $document, State, user, $timeout, TimeseriesService, RTSLService, ChartCompositionService, AssetService) { return {
 
     /**
      * Keeps omnibox size in check and creates and maintains a scrollbar.
@@ -151,6 +151,10 @@ angular.module("omnibox")
         throttled.cancel();
         window.Ps.destroy(cards[0]);
       });
+
+      scope.assetIsNested = function (asset) {
+        return AssetService.NESTED_ASSET_PREFIXES.indexOf(asset.entity_name) !== -1;
+      };
     },
 
     restrict: 'E',

--- a/app/components/omnibox/directives/omnibox-directives.js
+++ b/app/components/omnibox/directives/omnibox-directives.js
@@ -153,7 +153,7 @@ angular.module("omnibox")
       });
 
       scope.assetIsNested = function (asset) {
-        return AssetService.NESTED_ASSET_PREFIXES.indexOf(asset.entity_name) !== -1;
+        return AssetService.isNestedAsset(asset.entity_name);
       };
     },
 

--- a/app/components/omnibox/directives/template-directives.js
+++ b/app/components/omnibox/directives/template-directives.js
@@ -250,8 +250,13 @@ angular.module('omnibox')
 
           if (selection.timeseries &&
               (asset.timeseries || []).map(
-                function (asset) { return asset.uuid; }).indexOf(selection.timeseries) !== -1) {
-            ChartCompositionService.deactivateSelection(selection);
+                function (ts) { return ts.uuid; }).indexOf(selection.timeseries) !== -1) {
+
+            if (State.context === 'map') {
+              selection.active = false;
+            } else {
+              ChartCompositionService.deactivateSelection(selection);
+            }
           }
         });
       };

--- a/app/components/omnibox/templates/db-cards.html
+++ b/app/components/omnibox/templates/db-cards.html
@@ -28,7 +28,7 @@
             {{getGeomCardHeader(geom)}}
           </div>
           <div class="nested-asset-ts-count" translate>
-            {{countRasters(geom)}} {{ countRasters(geom) === 1 ? 'RASTER' : 'RASTERS' }}
+            {{countRasters(geom)}} {{ 'TEMPORAL ' + (countRasters(geom) === 1 ? 'RASTER' : 'RASTERS') }}
           </div>
         </div>
       </div>

--- a/app/components/omnibox/templates/db-cards.html
+++ b/app/components/omnibox/templates/db-cards.html
@@ -10,7 +10,8 @@
 
   <div
     class="card db-card active animate-repeat"
-    ng-repeat="geom in omnibox.data.geometries">
+    ng-repeat="geom in omnibox.data.geometries"
+    ng-if="mustShowGeomCard(geom)">
 
     <header class="card-header geom-card-header"
             ng-if="geom && geom.geometry.type === 'Point'">

--- a/app/components/omnibox/templates/omnibox.html
+++ b/app/components/omnibox/templates/omnibox.html
@@ -16,9 +16,10 @@
         asset="asset"
         show-header="true"
         show-annotations="showAnnotations()"
-        show-timeseries="(omnibox.data.geometries.length + omnibox.data.assets.length) < 2"
+        show-timeseries="true"
         time-state="omnibox.state.temporal"
-        ng-repeat="asset in omnibox.data.assets track by omnibox.trackAssets(asset)">
+        ng-repeat="asset in omnibox.data.assets track by omnibox.trackAssets(asset)"
+        ng-if="!assetIsNested(asset)">
       </asset-cards>
 
       <geometry-cards

--- a/app/components/state/selection-service.js
+++ b/app/components/state/selection-service.js
@@ -206,9 +206,6 @@ angular.module('global-state')
      * @return {object} asset or geometry data.
      */
     var initializeAssetSelections = function (asset) {
-      // IF asset === parentAsset:
-      // => voer onderstaande voor zowel parent als nested
-      // debugger;
       var colors = UtilService.GRAPH_COLORS;
       State.selections = _.unionWith(
         State.selections,

--- a/app/components/timeseries/timeseries-service.js
+++ b/app/components/timeseries/timeseries-service.js
@@ -319,16 +319,16 @@ angular.module('timeseries').service("TimeseriesService", [
                   activeTempRasterIds.push(selection.raster);
                 }
               }
-
             });
-            service.timeseries.forEach(function (ts) {
-              if (_.includes(activeTimeseriesUuids, ts.id)) {
-                if (!start || ts.start < start) {
-                  start = ts.start;
-                }
-                if (!end || ts.end > end) {
-                  end = ts.end;
-                }
+
+            var ts;
+            activeTimeseriesUuids.forEach(function (tsUuid) {
+              ts = _.find(service.timeseries, { id: tsUuid });
+              if (ts.start && (!start || ts.start < start)) {
+                start = ts.start;
+              }
+              if (ts.end && (!end || ts.end > end)) {
+                end = ts.end;
               }
             });
 
@@ -339,10 +339,11 @@ angular.module('timeseries').service("TimeseriesService", [
               rasterTsStart = dataLayer.firstValueTimestamp;
               rasterTsEnd = dataLayer.lastValueTimestamp;
 
-              if (!start || rasterTsStart < start) {
+              if (rasterTsStart && (!start || rasterTsStart < start)) {
                 start = rasterTsStart;
               }
-              if (!end || rasterTsEnd > end) {
+
+              if (rasterTsStart && (!end || rasterTsEnd > end)) {
                 end = rasterTsEnd;
               }
             });

--- a/app/components/timeseries/timeseries-service.js
+++ b/app/components/timeseries/timeseries-service.js
@@ -333,16 +333,13 @@ angular.module('timeseries').service("TimeseriesService", [
             });
 
             var dataLayer, rasterTsStart, rasterTsEnd;
-
             activeTempRasterIds.forEach(function (rasterId) {
               dataLayer = _.find(DataService.dataLayers, { uuid: rasterId });
               rasterTsStart = dataLayer.firstValueTimestamp;
               rasterTsEnd = dataLayer.lastValueTimestamp;
-
               if (rasterTsStart && (!start || rasterTsStart < start)) {
                 start = rasterTsStart;
               }
-
               if (rasterTsStart && (!end || rasterTsEnd > end)) {
                 end = rasterTsEnd;
               }


### PR DESCRIPTION
Related to asset-cards:
- [x] Switching ctx preserves chart order for both nested and non-nested assets
- [x] Closing asset cards (in dashboard ctx) interacts as expected with the db chart composition 
- [x] Closing asset cards (in map ctx) interacts as expected with the db chart composition
- [x] Closing asset cards (in map ctx) by selecting another asset while having single-point tool active works as expected.
- [x] Fixed dangerous/fatal typo in dashboard-service
- [x] Hovering the colored circles on y-axis of db planes gives tooltip showing the amount of charts for the current y-axis within that plane.

Related to geometry-cards:
- [x] Geom cards in db: don't show these cards when no temporal rasters are active
- [x] Geom cards in db: show amount of active temporal rasters (i.e. don't count rasters like Hoogte) 
- [x] Geom cards in db: closing card updates selections/composedCharts OK
- [x] Geom cards in map: closing card updates selections/composedCharts OK
- [ ] Get everything to work for geometries like it does for assets

Related to D3:
- [x] Prevent barchart crash (map ctx) when having received insufficient data from backend

Various:
- [x] Zoom-to-temporal magic for a collection of timeseries (dashboard-only) now still works when one-or-more ts have insufficient metadata (i.e. start/stop are null).