### PR TITLE
[DONE] Prevent overwrite for asset attribute 'type'

### DIFF
--- a/app/lib/click-feedback-service.js
+++ b/app/lib/click-feedback-service.js
@@ -103,8 +103,8 @@ angular.module('lizard-nxt')
         });
 
         // W/o this, the geojson can get an invalid 'type' attr: e.g.
-        // "pumpstation" a.o.t "Feature" xor "FeatureSet" (which would crash
-        // Leaflet)
+        // "Rioolgemaal", a.o.t "Feature" xor "FeatureSet" (only the latter two
+        // will *not* crash Leaflet)
         obj.type = 'Feature';
 
         // W/o this, the labels can remain blanco when the 'name' attr was not

--- a/app/lib/click-feedback-service.js
+++ b/app/lib/click-feedback-service.js
@@ -101,6 +101,16 @@ angular.module('lizard-nxt')
         _.forEach(asset, function (v, k) {
           obj[k] = v;
         });
+
+        // W/o this, the geojson can get an invalid 'type' attr: e.g.
+        // "pumpstation" a.o.t "Feature" xor "FeatureSet" (which would crash
+        // Leaflet)
+        obj.type = 'Feature';
+
+        // W/o this, the labels can remain blanco when the 'name' attr was not
+        // configured/filled in @backend:
+        obj.name = obj.name || '...';
+
         this.labelsLayer.addData(obj);
       };
 


### PR DESCRIPTION
Also, show ellipsis in label when `name` attribute was not present/filled-in in the API response.