### PR TITLE
[DONE] Fix addlayer glitch

### DIFF
--- a/app/components/data-menu/data-layer-adder-directive.js
+++ b/app/components/data-menu/data-layer-adder-directive.js
@@ -17,7 +17,14 @@ angular.module('data-menu')
 
     var link = function (scope, element, attrs) {
       var isEdge = navigator.appVersion.indexOf("Edge") > -1;
-      scope.availableLayers = [];
+      var EMPTY_RESPONSE = {
+        count: 0,
+        next: null,
+        previous: null,
+        results: []
+      };
+
+      scope.availableLayers = _.clone(EMPTY_RESPONSE);
 
       /**
        * Throw an alert and error when something went wrong with fetching the
@@ -29,7 +36,7 @@ angular.module('data-menu')
         notie.alert(
           3, gettextCatalog.getString(
             "Oops! Something went wrong while fetching the layers."));
-        scope.availableLayers = [];
+        scope.availableLayers = _.clone(EMPTY_RESPONSE);
         throw new Error(
           httpResponse.status + " - "
           + "Could not retrieve layers:"


### PR DESCRIPTION
Fix for: https://github.com/nens/lizard-nxt/issues/2501

Keep iterable datastructure consistent on fetch error.

I.e. it should look exactly like an empty response:

```
{
  count: 0,
  previous: null,
  next: null,
  results: [ ]
}
```
With this solution we prevent any unexpected behaviour in the HTML template (e.g. the visual glitch which only appears in rare cases). You see, this .html file expects the keys to be available in the datastructure called `availableLayers` (i.e. it  expects that the server always politely answers). When the server does not answer, we mock the empty response, thereby preventing the glitched rendering.
