### PR TITLE
[DONE] Dirk scenario raster export btn

### DIFF
--- a/app/components/data-menu/layer-directives/scenariolayer-directive.js
+++ b/app/components/data-menu/layer-directives/scenariolayer-directive.js
@@ -4,10 +4,12 @@ angular.module('data-menu')
 .directive('scenario', [
   '$http',
   'State',
+  'DataService',
   'LayerAdderService',
   'MapService',
   'gettextCatalog',
-  function ($http, State, LayerAdderService, MapService, gettextCatalog) {
+  '$timeout',
+  function ($http, State, DataService, LayerAdderService, MapService, gettextCatalog, $timeout) {
     var link = function (scope) {
 
       var RESULT_TYPES = {
@@ -154,6 +156,24 @@ angular.module('data-menu')
         _.forEach(scenarioLayers, LayerAdderService.remove);
       });
 
+      scope.mustShowExportBtn = function (result) {
+        var shortUuid = result.raster.uuid.slice(0, 7);
+        return DataService.layerIntersectsExtent(shortUuid);
+      };
+
+      scope.launchExportModal = function (result) {
+        var shortUuid = result.raster.uuid.slice(0, 7);
+        var clickableBtn = $('#user-menu-export-btn');
+        $timeout(function () {
+          clickableBtn.trigger('click');
+          $timeout(function () {
+            var tabElem = $('#export-modal-tab-btn-rasters');
+            tabElem.trigger('click');
+            var wantedOpt = $('option[value="' + shortUuid + '"]')
+            wantedOpt.prop('selected', true);
+          });
+        });
+      };
     };
 
     return {

--- a/app/components/data-menu/layer-directives/scenariolayer-directive.js
+++ b/app/components/data-menu/layer-directives/scenariolayer-directive.js
@@ -145,9 +145,7 @@ angular.module('data-menu')
       scope.$on('$destroy', function () {
         scope.layer.active = false;
         MapService.updateLayers([scope.layer]);
-
         var scenarioLayers = [];
-
         _.forEach(State.layers, function (layer) {
           if (layer.scenario && layer.scenario === scope.layer.uuid) {
             scenarioLayers.push(layer);
@@ -158,7 +156,9 @@ angular.module('data-menu')
 
       scope.mustShowExportBtn = function (result) {
         var shortUuid = result.raster.uuid.slice(0, 7);
-        return DataService.layerIntersectsExtent(shortUuid);
+        var stateLayer = _.find(State.layers, { uuid: shortUuid });
+        return stateLayer.active &&
+          DataService.layerIntersectsExtent(shortUuid);
       };
 
       scope.launchExportModal = function (result) {

--- a/app/components/data-menu/layer-directives/scenariolayer-directive.js
+++ b/app/components/data-menu/layer-directives/scenariolayer-directive.js
@@ -155,10 +155,6 @@ angular.module('data-menu')
       });
 
       scope.mustShowExportBtn = function (result) {
-        // var shortUuid = result.raster.uuid.slice(0, 7);
-        // var stateLayer = _.find(State.layers, { uuid: shortUuid });
-        // return stateLayer.active &&
-        //   DataService.layerIntersectsExtent(shortUuid);
         var shortUUID = State.shortenUUID(result.raster.uuid),
             stateLayer = State.findLayer(shortUUID);
         return stateLayer.active &&

--- a/app/components/data-menu/layer-directives/scenariolayer-directive.js
+++ b/app/components/data-menu/layer-directives/scenariolayer-directive.js
@@ -155,21 +155,25 @@ angular.module('data-menu')
       });
 
       scope.mustShowExportBtn = function (result) {
-        var shortUuid = result.raster.uuid.slice(0, 7);
-        var stateLayer = _.find(State.layers, { uuid: shortUuid });
+        // var shortUuid = result.raster.uuid.slice(0, 7);
+        // var stateLayer = _.find(State.layers, { uuid: shortUuid });
+        // return stateLayer.active &&
+        //   DataService.layerIntersectsExtent(shortUuid);
+        var shortUUID = State.shortenUUID(result.raster.uuid),
+            stateLayer = State.findLayer(shortUUID);
         return stateLayer.active &&
-          DataService.layerIntersectsExtent(shortUuid);
+          DataService.layerIntersectsExtent(shortUUID);
       };
 
       scope.launchExportModal = function (result) {
-        var shortUuid = result.raster.uuid.slice(0, 7);
+        var shortUuid = State.shortenUUID(result.raster.uuid);
         var clickableBtn = $('#user-menu-export-btn');
         $timeout(function () {
           clickableBtn.trigger('click');
           $timeout(function () {
             var tabElem = $('#export-modal-tab-btn-rasters');
             tabElem.trigger('click');
-            var wantedOpt = $('option[value="' + shortUuid + '"]')
+            var wantedOpt = $('option[value="' + shortUuid + '"]');
             wantedOpt.prop('selected', true);
           });
         });

--- a/app/components/data-menu/services/data-service.js
+++ b/app/components/data-menu/services/data-service.js
@@ -533,9 +533,13 @@ angular.module('data-menu')
         return assets;
       };
 
-      this.layerIntersectsExtent = function (layer) {
+      this.layerIntersectsExtent = function (layerUuid) {
+        var layer = _.find(this.dataLayers, { uuid: layerUuid });
+        if (!layer) {
+          return false;
+        }
         if (!layer.bounds) {
-          console.error("[E] layer does not have attr 'bounds'. Layer looks like:", layer);
+          console.error("[E] Layer does not have attr 'bounds'. Layer looks like:", layer);
         }
         var layerBounds = layer.bounds;
         var cornerNE = L.latLng(layerBounds.north, layerBounds.east);

--- a/app/components/data-menu/templates/scenario.html
+++ b/app/components/data-menu/templates/scenario.html
@@ -94,20 +94,6 @@
               </span>
             </span>
           </td>
-
-          <!--
-          <td class="col-md-3">
-            <div ng-if="result.result_type.has_attachment">
-              <a target="_blank"
-                 href="{{ result.attachment_url }}"
-                 class="btn btn-default btn-xs pull-right"
-                 title="{{ 'Export scenario data' | translate }}">
-                <i class="fa fa-share-square-o"></i>
-                <span translate>Export</span>
-              </a>
-            </div>
-          </td>
-          -->
           <td class="col-md-3">
             <div ng-if="mustShowExportBtn(result)">
               <a href="#"
@@ -119,7 +105,6 @@
               </a>
             </div>
           </td>
-
         </tr>
       </table>
     </div>

--- a/app/components/data-menu/templates/scenario.html
+++ b/app/components/data-menu/templates/scenario.html
@@ -94,6 +94,8 @@
               </span>
             </span>
           </td>
+
+          <!--
           <td class="col-md-3">
             <div ng-if="result.result_type.has_attachment">
               <a target="_blank"
@@ -105,6 +107,19 @@
               </a>
             </div>
           </td>
+          -->
+          <td class="col-md-3">
+            <div ng-if="mustShowExportBtn(result)">
+              <a href="#"
+                 ng-click="launchExportModal(result)"
+                 class="btn btn-default btn-xs pull-right"
+                 title="{{ 'Export scenario data' | translate }}">
+                <i class="fa fa-share-square-o"></i>
+                <span translate>Export</span>
+              </a>
+            </div>
+          </td>
+
         </tr>
       </table>
     </div>

--- a/app/components/export/export-rasters-directive.js
+++ b/app/components/export/export-rasters-directive.js
@@ -41,7 +41,7 @@ function (user,   DataService,   State,   UtilService,   $timeout,   gettextCata
 
     _.forEach(dataLayers, function (dataLayer) {
 
-      if (!DataService.layerIntersectsExtent(dataLayer)) {
+      if (!DataService.layerIntersectsExtent(dataLayer.uuid)) {
         return;
       }
 

--- a/app/components/state/state-service.js
+++ b/app/components/state/state-service.js
@@ -352,5 +352,23 @@ function (UtilService, gettextCatalog, $http) {
     return _.find(state.layers, {uuid: uuid});
   };
 
+  state.shortenUUID = function (uuid) {
+    var SHORT_UUID_LENGTH = 7;
+    return uuid.length > SHORT_UUID_LENGTH
+      ? uuid.slice(0, SHORT_UUID_LENGTH)
+      : uuid;
+  };
+
+  state.findLayer = function (uuid) {
+    var shortUUID = state.shortenUUID(uuid),
+        stateLayer = _.find(state.layers, { uuid: shortUUID });
+
+    if (!stateLayer) {
+      console.error("[E] Couldn't find stateLayer with UUID:", shortUUID);
+    } else {
+      return stateLayer;
+    }
+  };
+
   return state;
 }]);

--- a/app/components/state/state-service.js
+++ b/app/components/state/state-service.js
@@ -362,7 +362,6 @@ function (UtilService, gettextCatalog, $http) {
   state.findLayer = function (uuid) {
     var shortUUID = state.shortenUUID(uuid),
         stateLayer = _.find(state.layers, { uuid: shortUUID });
-
     if (!stateLayer) {
       console.error("[E] Couldn't find stateLayer with UUID:", shortUUID);
     } else {

--- a/app/components/ui-utils/modal-base.html
+++ b/app/components/ui-utils/modal-base.html
@@ -21,6 +21,7 @@
         <li role="presentation"
             class="active">
           <a href="#timeseries"
+             id="export-modal-tab-btn-timeseries"
              aria-controls="home"
              role="tab"
              data-toggle="tab"
@@ -31,6 +32,7 @@
 
         <li role="presentation">
           <a href="#timeseries-rasters"
+             id="export-modal-tab-btn-timeseries-rasters"
              aria-controls="profile"
              role="tab"
              data-toggle="tab"
@@ -41,6 +43,7 @@
 
         <li role="presentation">
           <a href="#rasters"
+             id="export-modal-tab-btn-rasters"
              aria-controls="profile"
              role="tab"
              data-toggle="tab"

--- a/app/components/user-menu/user-menu.html
+++ b/app/components/user-menu/user-menu.html
@@ -42,7 +42,7 @@
              title="{{ 'Export all selected timeseries' | translate }}"
              href="">
             <i class="fa fa-space-shuttle"></i>
-            <span translate>Export</span>
+            <span id="user-menu-export-btn" translate>Export</span>
           </a>
         </li>
         <li>

--- a/app/lib/util-service.js
+++ b/app/lib/util-service.js
@@ -1192,18 +1192,18 @@ angular.module('lizard-nxt')
     });
   };
 
-    this.dateToLocaleDependentString = function (dateObject) {
-      if (!dateObject) {
-        return '...';
-      }
+  this.dateToLocaleDependentString = function (dateObject) {
+    if (!dateObject) {
+      return '...';
+    }
 
-      var locale = window.navigator.language || window.navigator.browserLanguage;
+    var locale = window.navigator.language || window.navigator.browserLanguage;
 
-      if (locale) {
-        return dateObject.toLocaleString(locale);
-      } else {
-        // Can't find it, this uses a default locale (probably en-US)
-        return dateObject.toLocaleString();
-      }
-    };
+    if (locale) {
+      return dateObject.toLocaleString(locale);
+    } else {
+      // Can't find it, this uses a default locale (probably en-US)
+      return dateObject.toLocaleString();
+    }
+  };
 }]);


### PR DESCRIPTION
The deprecated export button in the datamenu (shown next to 3DI scenario rasters) now launches the export modal with both the correct tab and the correct raster selected in the dropdown. To prevent geotiff-export crashes we (i) no longer show a non-extent-intersecting raster (also applies when launching the modal via the usermenu) and (ii) we dynamically show/hide the formerly-deprecated export button to be consistent with the contents of the export-modal.