### PR TITLE
[DONE] A tale of two exports and a single button

### DIFF
--- a/app/components/data-menu/layer-directives/scenariolayer-directive.js
+++ b/app/components/data-menu/layer-directives/scenariolayer-directive.js
@@ -155,7 +155,6 @@ angular.module('data-menu')
       });
 
       scope.mustEnableExportBtn = function (result) {
-        // console.log("[F] mustEnableExportButton; result =", result);
         var shortUUID = State.shortenUUID(result.raster.uuid);
         return DataService.layerIntersectsExtent(shortUUID);
       };
@@ -172,19 +171,6 @@ angular.module('data-menu')
             wantedOpt.prop('selected', true);
           });
         });
-      };
-
-      scope.getAttachmentURL = function (result) {
-        console.log("[F] getAttachmentURL; result =", result);
-        if (result.attachment_url === null) {
-          return 'javascript:alert("Cannot find attachment not found");';
-        } else {
-          return result.attachment_url;
-        }
-      };
-
-      scope.dbg = function (result) {
-        console.log("[F] DBG; result =", result);
       };
     };
 

--- a/app/components/data-menu/layer-directives/scenariolayer-directive.js
+++ b/app/components/data-menu/layer-directives/scenariolayer-directive.js
@@ -155,10 +155,9 @@ angular.module('data-menu')
       });
 
       scope.mustEnableExportBtn = function (result) {
-        var shortUUID = State.shortenUUID(result.raster.uuid),
-            stateLayer = State.findLayer(shortUUID);
-        return stateLayer.active &&
-          DataService.layerIntersectsExtent(shortUUID);
+        // console.log("[F] mustEnableExportButton; result =", result);
+        var shortUUID = State.shortenUUID(result.raster.uuid);
+        return DataService.layerIntersectsExtent(shortUUID);
       };
 
       scope.launchExportModal = function (result) {
@@ -173,6 +172,19 @@ angular.module('data-menu')
             wantedOpt.prop('selected', true);
           });
         });
+      };
+
+      scope.getAttachmentURL = function (result) {
+        console.log("[F] getAttachmentURL; result =", result);
+        if (result.attachment_url === null) {
+          return 'javascript:alert("Cannot find attachment not found");';
+        } else {
+          return result.attachment_url;
+        }
+      };
+
+      scope.dbg = function (result) {
+        console.log("[F] DBG; result =", result);
       };
     };
 

--- a/app/components/data-menu/templates/scenario.html
+++ b/app/components/data-menu/templates/scenario.html
@@ -15,7 +15,6 @@
           </div>
       </label>
     </div>
-
     <opacity-slider title="{{ tooltips.transparency }}" layer="{active: false}"></opacity-slider>
   </div>
 

--- a/app/components/data-menu/templates/scenario.html
+++ b/app/components/data-menu/templates/scenario.html
@@ -93,25 +93,38 @@
               </span>
             </span>
           </td>
+
           <td class="col-md-3">
             <div>
+
               <a href="#"
                  ng-click="launchExportModal(result)"
                  class="btn btn-default btn-xs pull-right"
                  title="{{ 'Export scenario data' | translate }}"
-                 ng-if="!mustEnableExportBtn(result)"
+                 ng-if="result.result_type.has_raster && !mustEnableExportBtn(result)"
                  disabled>
                 <i class="fa fa-share-square-o"></i>
                 <span translate>Export</span>
               </a>
+
               <a href="#"
                  ng-click="launchExportModal(result)"
                  class="btn btn-default btn-xs pull-right"
                  title="{{ 'Export scenario data' | translate }}"
-                 ng-if="mustEnableExportBtn(result)">
+                 ng-if="result.result_type.has_raster && mustEnableExportBtn(result)">
                 <i class="fa fa-share-square-o"></i>
                 <span translate>Export</span>
               </a>
+
+              <a href="{{ result.attachment_url || '#' }}"
+                 class="btn btn-default btn-xs pull-right"
+                 title="{{ 'Export scenario data' | translate }}"
+                 ng-if="!result.result_type.has_raster && result.result_type.has_attachment && result.attachment_url">
+                <i ng-init="dbg(result)"
+                   class="fa fa-share-square-o"></i>
+                <span translate>Export</span>
+              </a>
+
             </div>
           </td>
         </tr>

--- a/app/components/export/export-rasters-directive.js
+++ b/app/components/export/export-rasters-directive.js
@@ -46,7 +46,7 @@ function (user,   DataService,   State,   UtilService,   $timeout,   gettextCata
       }
 
       stateLayer = _.find(State.layers, { uuid: dataLayer.uuid });
-      if (stateLayer.type === 'scenario' || !stateLayer.active) {
+      if (stateLayer.type === 'scenario') {
         return;
       }
       key = _getKey(dataLayer, stateLayer);
@@ -71,7 +71,9 @@ function (user,   DataService,   State,   UtilService,   $timeout,   gettextCata
     return theDateElem.value + ":00";
   }
 
-  function isNumeric (x) { return !isNaN(parseFloat(x)) && isFinite(x); }
+  function isNumeric (x) {
+    return !isNaN(parseFloat(x)) && isFinite(x);
+  }
 
   function exportCbAuthenticatedUser (response) {
     angular.element('#MotherModal').modal('hide');
@@ -141,7 +143,7 @@ function (user,   DataService,   State,   UtilService,   $timeout,   gettextCata
         variableParams.time = getDatetime();
       }
 
-      // IE doesnt support Object.assign calls....
+      // IE doesn't support Object.assign calls....
       _.forEach(variableParams, function (v, k) {
         DEFAULT_PARAMS[k] = v;
       });


### PR DESCRIPTION
Description:
---
At the moment (20-03-2018) we are able to launch the export modal, via a button (B1) in the layermenu, for rasters that belong to a single 3Di scenario's result. However, an equivalent and visually indistinguishable button (B2) should be shown in the layermenu for attachments that belong to single 3Di scenario's result. Different in behaviour, B2 still needs some work. 

The behaviour of the B1 type buttons:

* Enabling/disabling the button depends on the client's current spatial extent; we don't want the user to be able to export raster data when his current spatial extent has no overlap with the raster.
* Clicking it launches the export modal (tab: "rasters", used for geotiff export) with the related raster selected in the dropdown.

The difference of B2 type buttons compared to B1 type buttons:

* Enabling/disabling the button does _not_ depend on the client's current spatial extent
* Clicking it should download the attachment,  e.g: `<a href="/tmp/piz.zip" target="_blank" ...>`

TODO:
---
- [x] Configure in django admin, a scenario result with: has_attachment=0 && has_raster=1
- [x] Configure in django admin, a scenario result with: has_attachment=1 && has_raster=0
- [x] Compare: layermenu@localhost with layermenu@staging. Does it look representative?
- [ ] [primary] Make sure that attr 'attachment_url' refers to existing file on disk ??? At least...
- [x] [subsidiary] ...make sure that dl-ing of attachments would work, assuming the file would be on disk.
- [x] Write actual code to make stuff happen
- [x] localhost: test thoroughly  (everything but dl-ing attachments)
- [x] staging: test thoroughly: the dl-ing attachments _...herp-a-derp catch22 wut is dat?_
- [x] ???
- [x] PROFIT