### PR TITLE
Replace google geocoder with mapbox, hardcoded access token

### DIFF
--- a/app/components/omnibox/directives/omnibox-directives.js
+++ b/app/components/omnibox/directives/omnibox-directives.js
@@ -28,11 +28,8 @@ angular.module("omnibox")
 
       scope.onFocus = function(item, $event) {
         item.selected = "selected";
-        if (item.hasOwnProperty('formatted_address')) {
+        if (item.hasOwnProperty('place_name')) {
           scope.zoomToSpatialResultWithoutClearingSeach(item);
-        }
-        if (item.hasOwnProperty('entity_url')) {
-          scope.zoomToSearchResultWithoutClearingSearch(item);
         }
       };
 

--- a/app/components/omnibox/directives/search-directive.js
+++ b/app/components/omnibox/directives/search-directive.js
@@ -202,8 +202,6 @@ angular.module('omnibox')
      * promise resolves with response from geocoder.
      */
     var setResultsOnBox = function (results) {
-      var MAX_RESULTS = 3;
-
       if (
         results.temporal.isValid()
         && results.temporal.valueOf() > UtilService.MIN_TIME
@@ -220,20 +218,14 @@ angular.module('omnibox')
             if (scope.omnibox.searchResults === undefined) { return; }
 
             // Either put results on scope or remove model.
-            if (response.status === SearchService.responseStatus.OK) {
-              var results = response.results;
-              // limit to MAX_RESULTS results
-              if (results.length >  MAX_RESULTS) {
-                results = results.splice(0, MAX_RESULTS);
-              }
-              scope.omnibox.searchResults.spatial = results;
+            if ("features" in response) {
+              var features = response.features;
+              scope.omnibox.searchResults.spatial = features;
             }
-            else if (
-              response.status !== SearchService.responseStatus.ZERO_RESULTS
-            ) {
+            else {
               // Throw error so we can find out about it through sentry.
               throw new Error(
-                'Geocoder returned with status: ' + response.status
+                'Mapbox geocoder returned with status: ' + response.message
               );
             }
 

--- a/app/components/omnibox/directives/search-directive.js
+++ b/app/components/omnibox/directives/search-directive.js
@@ -121,7 +121,7 @@ angular.module('omnibox')
      * @param {object} one search result.
      */
     scope.zoomToSpatialResult = function (result) {
-      State = SearchService.zoomToGoogleGeocoderResult(result, State);
+      State = SearchService.zoomToGeocoderResult(result, State);
       scope.cleanInputAndResults();
     };
 
@@ -130,7 +130,7 @@ angular.module('omnibox')
      * @param {object} one search result.
      */
     scope.zoomToSpatialResultWithoutClearingSeach = function (result) {
-      State = SearchService.zoomToGoogleGeocoderResult(result, State);
+      State = SearchService.zoomToGeocoderResult(result, State);
     };
 
     /**

--- a/app/components/omnibox/services/search-service.js
+++ b/app/components/omnibox/services/search-service.js
@@ -29,15 +29,6 @@ angular.module('omnibox')
       gettextCatalog
       ) {
 
-    this.responseStatus = {
-        OK: 'OK',
-        ZERO_RESULTS: 'ZERO_RESULTS',
-        OVER_QUERY_LIMIT: 'OVER_QUERY_LIMIT',
-        REQUEST_DENIED: 'REQUEST_DENIED',
-        INVALID_REQUEST: 'INVALID_REQUEST',
-        UNKNOWN_ERROR: 'UNKNOWN_ERROR'
-    };
-
     var localPromise = {};
 
     this.cancel = function () {
@@ -109,20 +100,23 @@ angular.module('omnibox')
       };
 
       var bounds;
+      var MAX_RESULTS = '3';
       // bounds are not available in the dashboard view.
       if (state.spatial.bounds.getSouth) {
           bounds = // Prefer results from the current viewport
+            state.spatial.bounds.getWest() + ',' +
             state.spatial.bounds.getSouth() + ',' +
-            state.spatial.bounds.getWest() + '|' +
-            state.spatial.bounds.getNorth() + ',' +
-            state.spatial.bounds.getEast();
+            state.spatial.bounds.getEast() + ',' +
+            state.spatial.bounds.getNorth();
       }
       // TODO: request results in portals language and restrict results based
       // on portal by adding: components: 'country:NL'.
-      var prom = CabinetService.geocode.get({
-        address: searchString,
+      var prom = CabinetService.geocode(searchString).get({
+        access_token: 'pk.eyJ1IjoibmVsZW5zY2h1dXJtYW5zIiwiYSI6ImNqaGE5YmVxbTBveW4zYXFoOXFzbmZjazcifQ.7RlZNff2s2GU0OH4UWtIzA',
         language: state.language, // Preferred language of search results.
-        bounds: bounds
+        bounds: bounds,
+        limit: MAX_RESULTS,
+        autocomplete: 'false'
       });
 
       var moment = dateParser(searchString);
@@ -145,8 +139,8 @@ angular.module('omnibox')
      */
     this.zoomToGoogleGeocoderResult = function (result, state) {
       state.spatial.bounds = LeafletService.latLngBounds(
-        LeafletService.latLng(result.geometry.viewport.southwest),
-        LeafletService.latLng(result.geometry.viewport.northeast)
+        LeafletService.latLng(result.bbox[3], result.bbox[2]),
+        LeafletService.latLng(result.bbox[1], result.bbox[0])
       );
       return state;
     };

--- a/app/components/omnibox/services/search-service.js
+++ b/app/components/omnibox/services/search-service.js
@@ -137,7 +137,7 @@ angular.module('omnibox')
      *
      * @param  {object} result google geocoder result.
      */
-    this.zoomToGoogleGeocoderResult = function (result, state) {
+    this.zoomToGeocoderResult = function (result, state) {
       state.spatial.bounds = LeafletService.latLngBounds(
         LeafletService.latLng(result.bbox[3], result.bbox[2]),
         LeafletService.latLng(result.bbox[1], result.bbox[0])

--- a/app/components/omnibox/templates/search-results.html
+++ b/app/components/omnibox/templates/search-results.html
@@ -30,7 +30,7 @@
         <i class="fa fa-location-arrow">&nbsp;</i>
         <a ng-click="zoomToSpatialResult(result)"
           href="">
-          <span title="{{ result.formatted_address }}">{{ result.formatted_address }}</span>
+          <span title="{{ result.place_name }}">{{ result.place_name }}</span>
         </a>
       </li>
     </ul>

--- a/app/lib/cabinet-service.js
+++ b/app/lib/cabinet-service.js
@@ -26,10 +26,10 @@ angular.module('lizard-nxt')
   // Wms getFeatureInfo goes through a proxy. Specify url as a param.
   var wmsGetFeatureInfo = new Resource.Endpoint('proxy/');
 
-  var geocodeResource = new Resource.Endpoint('api/geocode/json')
-    // Use a different base url, go directly to our friends at google.
-    // They don't mind.
-    .setBaseUrl('https://maps.googleapis.com/maps/');
+  var geocodeResource = function (q) {
+    return new Resource.Endpoint('geocoding/v5/mapbox.places/' + q + '.json')
+        .setBaseUrl('https://api.mapbox.com/');
+  };
 
   /**
    * Raster resource, last stop to the server

--- a/app/lib/cabinet-service.js
+++ b/app/lib/cabinet-service.js
@@ -27,7 +27,8 @@ angular.module('lizard-nxt')
   var wmsGetFeatureInfo = new Resource.Endpoint('proxy/');
 
   var geocodeResource = function (q) {
-    return new Resource.Endpoint('geocoding/v5/mapbox.places/' + q + '.json')
+    return new Resource.Endpoint('geocoding/v5/mapbox.places/' +
+        q.replace(/[^a-zA-Z0-9-_]/g, '') + '.json')
         .setBaseUrl('https://api.mapbox.com/');
   };
 

--- a/test/spec/search-service.js
+++ b/test/spec/search-service.js
@@ -8,7 +8,7 @@ describe('Service: SearchService', function () {
   // instantiate service
   var SearchService,
       State,
-      ggResult = {
+      gResult = {
         "type": "FeatureCollection",
         "query": [
           "los",
@@ -115,9 +115,9 @@ describe('Service: SearchService', function () {
   });
 
   it('should set bounds of search result on State', function () {
-    SearchService.zoomToGoogleGeocoderResult(ggResult.features[0], State);
+    SearchService.zoomToGeocoderResult(gResult.features[0], State);
     expect(State.spatial.bounds._southWest.lat)
-      .toBe(ggResult.features[0].bbox[1]);
+      .toBe(gResult.features[0].bbox[1]);
   });
 
 });

--- a/test/spec/search-service.js
+++ b/test/spec/search-service.js
@@ -9,29 +9,58 @@ describe('Service: SearchService', function () {
   var SearchService,
       State,
       ggResult = {
-        'results' : [
+        "type": "FeatureCollection",
+        "query": [
+          "los",
+          "angeles"
+        ],
+        "features": [
           {
-            'formatted_address' : '1600 Amphitheatre Parkway, Mountain View, CA 94043, USA',
-            'geometry' : {
-              'location' : {
-                'lat' : 37.4224764,
-                'lng' : -122.0842499
+            "id": "place.9962989141465270",
+            "type": "Feature",
+            "place_type": [
+              "place"
+            ],
+            "relevance": 0.99,
+            "properties": {
+              "wikidata": "Q65"
+            },
+            "text": "Los Angeles",
+            "place_name": "Los Angeles, California, United States",
+            "bbox": [
+              -118.529221009603,
+              33.901599990108,
+              -118.121099990025,
+              34.1612200099034
+            ],
+            "center": [
+              -118.2439,
+              34.0544
+            ],
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2439,
+                34.0544
+              ]
+            },
+            "context": [
+              {
+                "id": "region.3591",
+                "short_code": "US-CA",
+                "wikidata": "Q99",
+                "text": "California"
               },
-              'location_type' : 'ROOFTOP',
-              'viewport' : {
-                'northeast' : {
-                  'lat' : 37.4238253802915,
-                  'lng' : -122.0829009197085
-                },
-                'southwest' : {
-                  'lat' : 37.4211274197085,
-                  'lng' : -122.0855988802915
-                }
+              {
+                "id": "country.3145",
+                "short_code": "us",
+                "wikidata": "Q30",
+                "text": "United States"
               }
-            }
+            ]
           }
         ],
-        'status' : 'OK'
+        "attribution": "NOTICE."
       },
       endpointResult = {
         results: [
@@ -85,14 +114,10 @@ describe('Service: SearchService', function () {
     expect(!!result.spatial.then).toBe(true);
   });
 
-  it('should contain the google geocoder statuses', function () {
-    expect(SearchService.responseStatus.OK).toBe('OK');
-  });
-
   it('should set bounds of search result on State', function () {
-    SearchService.zoomToGoogleGeocoderResult(ggResult.results[0], State);
+    SearchService.zoomToGoogleGeocoderResult(ggResult.features[0], State);
     expect(State.spatial.bounds._southWest.lat)
-      .toBe(ggResult.results[0].geometry.viewport.southwest.lat);
+      .toBe(ggResult.features[0].bbox[1]);
   });
 
 });


### PR DESCRIPTION
Open vraag is de access token: deze is publiek en kan door iemand zo gekopieerd worden. Een mogelijkheid is om per sessie een tijdelijke key aan te maken vanuit de backend. Daar is een API voor bij Mapbox.

Voor nu heb ik een nieuwe Mapbox key aangemaakt om te hardcoden in de client. Deze is nieuw en kan dus zo weer verwijderd worden.