### PR TITLE
[DOING] alotta little thingies

### DIFF
--- a/app/components/favourites/favourites-directive.js
+++ b/app/components/favourites/favourites-directive.js
@@ -171,6 +171,28 @@ angular.module('favourites')
         httpResponse.status + " - " + "Could not create favourite.");
     };
 
+    /*
+    if a favourite is typed into the new favourites input then it returns true if
+    the name of this new favourite is unique (not already used by an existing favourite)
+    */
+    scope.isNameUniqueAmongFavourites = function () {
+      if (!scope.favourite) {
+        return true;
+      } else {
+        return scope.favourites.data.map(function(e){return e.name;})
+          .indexOf(scope.favourite.name) === -1;
+      }
+    };
+
+    /*
+    Decide if + (new) button should be disabled
+    */
+    scope.createNewButtonShouldBeDisabled = function () {
+      return (!scope.isNameUniqueAmongFavourites()) || scope.favouritesForm.$invalid;
+    };
+
+
+
     /**
      * Create a new favourite with the current portal state.
      */

--- a/app/components/favourites/favourites-directive.js
+++ b/app/components/favourites/favourites-directive.js
@@ -155,6 +155,10 @@ angular.module('favourites')
      */
     var createFavouriteSuccess = function(favourite, responseHeaders){
       scope.favourites.data.splice(0, 0, favourite);
+      // after creating new favourite is succesfull empty form
+      if (scope.favourite.name === favourite.name) {
+        scope.resetForm();
+      }
     };
 
     /**

--- a/app/components/favourites/templates/favourites-add.html
+++ b/app/components/favourites/templates/favourites-add.html
@@ -18,7 +18,6 @@
                  ng:model="favourite.name"
                  placeholder="{{ 'New favourite name...'|translate }}" />
           <div>
-          <!-- <div ng-show="favouritesForm.favourite.name.$dirty && (favouritesForm.favourite.name.$invalid || !isNameUniqueAmongFavourites())"> -->
             <small
               class="text-danger"
               ng-show="favouritesForm.favourite.name.$error.required"
@@ -41,7 +40,7 @@
         </td>
         <td>
           <button
-            class="btn btn-link"
+            class="btn btn-link favourites_button"
             ng-disabled="createNewButtonShouldBeDisabled()"
             ng-click="createFavourite()">
             <i class="fa fa-plus text-primary"></i>

--- a/app/components/favourites/templates/favourites-add.html
+++ b/app/components/favourites/templates/favourites-add.html
@@ -17,8 +17,8 @@
                  required
                  ng:model="favourite.name"
                  placeholder="{{ 'New favourite name...'|translate }}" />
-          <div
-            ng-show="favouritesForm.favourite.name.$dirty && favouritesForm.favourite.name.$invalid">
+          <div>
+          <!-- <div ng-show="favouritesForm.favourite.name.$dirty && (favouritesForm.favourite.name.$invalid || !isNameUniqueAmongFavourites())"> -->
             <small
               class="text-danger"
               ng-show="favouritesForm.favourite.name.$error.required"
@@ -31,12 +31,18 @@
               translate>
               Favourite name cannot be longer than 256 characters.
             </small>
+            <small
+              class="text-danger"
+              ng-show="!isNameUniqueAmongFavourites()"
+              translate>
+              Favourite name must be unique.
+            </small>
           </div>
         </td>
         <td>
           <button
             class="btn btn-link"
-            ng-disabled="favouritesForm.$invalid"
+            ng-disabled="createNewButtonShouldBeDisabled()"
             ng-click="createFavourite()">
             <i class="fa fa-plus text-primary"></i>
           </button>

--- a/app/components/graph/graph-directives.js
+++ b/app/components/graph/graph-directives.js
@@ -93,11 +93,29 @@ angular.module('lizard-nxt')
 
     var graphUpdateHelper = function () {
       if (scope.content) {
+        console.log('[F] graphUpdateHelper scope.content', scope.content);
         graphCtrl.setData(scope);
       }
       else if (scope.data) {
+        console.log('[F] graphUpdateHelper scope.data', scope.data);
         graphCtrl.setFormattedContent(scope);
       }
+      
+      // if no data is available in specified timeframe, then 
+      // the user should see text appear in the charts;
+      // "No data available i this timeframe"
+      // See Jira:
+      // https://nelen-schuurmans.atlassian.net/browse/PROJ-471
+      // we assume that when no data is available the data is an empty array
+      
+      // always remove previous text
+      graphCtrl.graph.setDisplayTextChartBody("");
+      if (
+        (scope.content && !graphCtrl.graph.hasContentToDisplay(scope.content)) ||
+        (scope.data && scope.data.length === 0)
+      ) {
+        graphCtrl.graph.setDisplayTextChartBody("No data available in this timeframe");
+      } 
 
       // UpdateData is called with temporal.timelineMoving to draw subset for
       // performance reasons.

--- a/app/components/graph/graph-directives.js
+++ b/app/components/graph/graph-directives.js
@@ -93,11 +93,9 @@ angular.module('lizard-nxt')
 
     var graphUpdateHelper = function () {
       if (scope.content) {
-        console.log('[F] graphUpdateHelper scope.content', scope.content);
         graphCtrl.setData(scope);
       }
       else if (scope.data) {
-        console.log('[F] graphUpdateHelper scope.data', scope.data);
         graphCtrl.setFormattedContent(scope);
       }
       
@@ -110,8 +108,12 @@ angular.module('lizard-nxt')
       
       // always remove previous text
       graphCtrl.graph.setDisplayTextChartBody("");
+      
+      // in case of scope.content first check if content has indeed a length, 
+      // because content will be empty for a moment after dragging timeline.
+      // during this brief moment it is not desired to show the "no data .." message
       if (
-        (scope.content && !graphCtrl.graph.hasContentToDisplay(scope.content)) ||
+        (scope.content && scope.content.length && !graphCtrl.graph.contentContainsDataToDisplay(scope.content)) ||
         (scope.data && scope.data.length === 0)
       ) {
         graphCtrl.graph.setDisplayTextChartBody("No data available in this timeframe");

--- a/app/components/graph/graph-directives.js
+++ b/app/components/graph/graph-directives.js
@@ -91,24 +91,16 @@ angular.module('lizard-nxt')
    */
   var link = function (scope, element, attrs, graphCtrl) {
 
-    var graphUpdateHelper = function () {
-      if (scope.content) {
-        graphCtrl.setData(scope);
-      }
-      else if (scope.data) {
-        graphCtrl.setFormattedContent(scope);
-      }
-      
-      // if no data is available in specified timeframe, then 
-      // the user should see text appear in the charts;
-      // "No data available i this timeframe"
-      // See Jira:
-      // https://nelen-schuurmans.atlassian.net/browse/PROJ-471
-      // we assume that when no data is available the data is an empty array
-      
+
+    // if no data is available in specified timeframe, then 
+    // the user should see text appear in the charts;
+    // "No data available i this timeframe"
+    // See Jira:
+    // https://nelen-schuurmans.atlassian.net/browse/PROJ-471
+    // we assume that when no data is available the data is an empty array
+    var addOrRemoveNoDataAvailableText = function () {
       // always remove previous text
       graphCtrl.graph.setDisplayTextChartBody("");
-      
       // in case of scope.content first check if content has indeed a length, 
       // because content will be empty for a moment after dragging timeline.
       // during this brief moment it is not desired to show the "no data .." message
@@ -118,6 +110,18 @@ angular.module('lizard-nxt')
       ) {
         graphCtrl.graph.setDisplayTextChartBody("No data available in this timeframe");
       } 
+    };
+    
+    var graphUpdateHelper = function () {
+      if (scope.content) {
+        graphCtrl.setData(scope);
+      }
+      else if (scope.data) {
+        graphCtrl.setFormattedContent(scope);
+      }
+      
+      addOrRemoveNoDataAvailableText();
+      
 
       // UpdateData is called with temporal.timelineMoving to draw subset for
       // performance reasons.

--- a/app/components/graph/graph-service.js
+++ b/app/components/graph/graph-service.js
@@ -86,7 +86,7 @@ angular.module('lizard-nxt')
    *                        Currently only a linear scale on the x-axis is
    *                        supported.
    */
-    Graph.prototype.drawLine = function (content, temporal, transitioning) {
+  Graph.prototype.drawLine = function (content, temporal, transitioning) {
     if (!content) { return; }
 
     var graph = this;
@@ -241,6 +241,60 @@ angular.module('lizard-nxt')
   /**
    * @function
    * @memberOf Graph
+   * @param {object} content - array: [{data:[{}]},{data:[]}, {}]
+   *                           array that contains 0 or more objects that each may contain a field called "data" that is itself an array of zero or more objects
+   *                           if any of those data fields have one or more items in the array return true (see description)
+   * @returns  - boolean
+   * @description           checks if content (from graph-directive scope.content) contains data.
+                            returns true if any of the objects in the content array contain a field data that is an array with 1 or more items
+                            otherwise returns false
+   */
+  
+  Graph.prototype.hasContentToDisplay = function (content) {
+    if (!content.length) {
+      // content is no array
+      return false;
+    }
+    var filledContent = content.filter(function (element){
+      if (element.data && element.data.length > 0)   
+        return true;
+      else
+        return false;
+    });
+    return filledContent.length > 0;
+  };
+
+  /**
+   * @function
+   * @memberOf Graph
+   * @param {object} text - string
+   * @description           displays text in the body of this chart. when no text shall be displayed pass empty string ''
+   */
+  Graph.prototype.setDisplayTextChartBody = function (text) {
+    var classNameText = "display_text_class";
+    var svg = this._svg;
+
+    // always remove previous text
+    svg.selectAll("text."+ classNameText).remove();
+
+    // if text to display is not empty string, then add text element with d3
+    if (text !== '') {
+      var fg = svg.select('g').select('#feature-group');
+        // bring to front
+        fg.node().parentNode.appendChild(fg.node());
+        path = fg.append("text")
+                 .attr('class', classNameText)
+                 .attr("x", "50%")
+                 .attr("y", "50%")
+                 .append("tspan")
+                 .attr("text-anchor", "middle")
+                 .text(text);
+    } 
+  };
+
+  /**
+   * @function
+   * @memberOf Graph
    * @param {object} barData - Object or Array with data, keys and labels
    *
    *         data   Currently supports arrays of arrays or objects
@@ -375,7 +429,7 @@ angular.module('lizard-nxt')
    *                        label and sets up a mousemove listener.
    *                        It draws the rectangles.
    */
-    Graph.prototype.drawHorizontalStack = function (content) {
+  Graph.prototype.drawHorizontalStack = function (content) {
       var data = content[0].data,
           keys = content[0].keys,
           labels = { x: content.xLabel, y: content.unit };
@@ -613,7 +667,7 @@ angular.module('lizard-nxt')
       );
   };
 
-    Graph.prototype.drawCircleOnLine = function (xLocation, remove) {
+  Graph.prototype.drawCircleOnLine = function (xLocation, remove) {
       var R = 5; // radius of dot.
 
       var fg = this._svg.select('#feature-group');
@@ -1176,7 +1230,7 @@ angular.module('lizard-nxt')
 
   };
 
-    var addInteractionToRects = function (svg, dimensions, xy, keys, labels, activeUnit, color) {
+  var addInteractionToRects = function (svg, dimensions, xy, keys, labels, activeUnit, color) {
       var unitClass = "unit-" + UtilService.slugify(activeUnit);
       var height = Graph.prototype._getHeight(dimensions),
           width = Graph.prototype._getWidth(dimensions),

--- a/app/components/graph/graph-service.js
+++ b/app/components/graph/graph-service.js
@@ -251,12 +251,14 @@ angular.module('lizard-nxt')
    */
   
   Graph.prototype.contentContainsDataToDisplay = function (content) {
+    // filter out elements with no or empty data
     var filledContent = content.filter(function (element){
       if (element.data && element.data.length > 0)   
         return true;
       else
         return false;
     });
+    // return true if array still contains elements
     return filledContent.length > 0;
   };
 
@@ -275,16 +277,14 @@ angular.module('lizard-nxt')
 
     // if text to display is not empty string, then add text element with d3
     if (text !== '') {
-      var fg = svg.select('g').select('#feature-group');
-        // bring to front
-        fg.node().parentNode.appendChild(fg.node());
-        path = fg.append("text")
-                 .attr('class', classNameText)
-                 .attr("x", "50%")
-                 .attr("y", "50%")
-                 .append("tspan")
-                 .attr("text-anchor", "middle")
-                 .text(text);
+      // add text to top svg element so layout is not impacted by tranformations of <g> layers
+      svg.append("text")
+        // add class so the text can also be removed safely
+        .attr('class', classNameText)
+        .attr("x", "50%")
+        .attr("y", "50%")
+        .attr("text-anchor", "middle")
+        .text(text);
     } 
   };
 

--- a/app/components/graph/graph-service.js
+++ b/app/components/graph/graph-service.js
@@ -250,11 +250,7 @@ angular.module('lizard-nxt')
                             otherwise returns false
    */
   
-  Graph.prototype.hasContentToDisplay = function (content) {
-    if (!content.length) {
-      // content is no array
-      return false;
-    }
+  Graph.prototype.contentContainsDataToDisplay = function (content) {
     var filledContent = content.filter(function (element){
       if (element.data && element.data.length > 0)   
         return true;

--- a/app/components/timeline/timeline-service.js
+++ b/app/components/timeline/timeline-service.js
@@ -112,7 +112,7 @@ angular.module('lizard-nxt')
           .attr("id", "nodata")
           .attr("x", xScale(Date.now()))
           .attr("opacity", 0.8)
-          .style("fill", "#DDD");
+          .style("fill", "#34495e");
       }
     },
 

--- a/app/lib/util-service.js
+++ b/app/lib/util-service.js
@@ -236,7 +236,7 @@ angular.module('lizard-nxt')
    * @return {int} milliseconds representation
    */
   this.parseDaysHours = function (timeString) {
-    if (timeString === undefined) 
+    if (timeString === undefined)
       return 0;
 
     var negativeTime = timeString[0] === '-';
@@ -256,7 +256,7 @@ angular.module('lizard-nxt')
 
     return negativeTime
       ? -1 * totalMS
-      : totalMS;  
+      : totalMS;
   };
 
   /**
@@ -271,7 +271,7 @@ angular.module('lizard-nxt')
 
     // only calculate if the end is gte than start
     if (end >= start) {
-      var totalHours, 
+      var totalHours,
           interval = end - start;
       totalHours = Math.round(interval / this.hour);
       days = Math.floor(totalHours / 24);
@@ -836,12 +836,18 @@ angular.module('lizard-nxt')
   this.TIMELINE_RIGHT_MARGIN = 40;
   this.OMNIBOX_WIDTH = 420;
 
+  var RESTRICT_TEMPORAL_BOUNDS = false;
+
   this.getMinTime = function (currentTime) {
-    return Math.max(this.MIN_TIME, currentTime);
+    return RESTRICT_TEMPORAL_BOUNDS
+      ? Math.max(this.MIN_TIME, currentTime)
+      : currentTime;
   };
 
   this.getMaxTime = function (currentTime) {
-    return Math.min(this.MAX_TIME, currentTime);
+    return RESTRICT_TEMPORAL_BOUNDS
+      ? Math.min(this.MAX_TIME, currentTime)
+      : currentTime;
   };
 
   this.getLeftMargin = function (context) {

--- a/app/styles/_bootstrap-overrides.scss
+++ b/app/styles/_bootstrap-overrides.scss
@@ -11,3 +11,7 @@ input::-webkit-input-placeholder { color: #ccc !important; }
 input:-moz-placeholder { color: #ccc !important; }
 input::-moz-placeholder { color: #ccc !important; }
 input:-ms-input-placeholder { color: #ccc !important; }
+
+.btn[disabled].favourites_button {
+  opacity: 0.3;
+}

--- a/app/styles/_timeline.scss
+++ b/app/styles/_timeline.scss
@@ -306,14 +306,12 @@
   transform: translateY(+100px);
 }
 
-<<<<<<< HEAD
 #timeline-svg-wrapper rect#listeners {
   fill: #ecf0f1;
   opacity: 0.4;
   cursor: col-resize;
 }
 
-=======
 #timeline-header {
   height: 20px;
   background-color: rgba(0,0,0,0);
@@ -341,4 +339,3 @@
 }
 
 
->>>>>>> eed3bbda4bde831f7ad8e9e17e420200341b65df

--- a/app/styles/_timeline.scss
+++ b/app/styles/_timeline.scss
@@ -306,3 +306,9 @@
   transform: translateY(+100px);
 }
 
+#timeline-svg-wrapper rect#listeners {
+  fill: #ecf0f1;
+  opacity: 0.4;
+  cursor: col-resize;
+}
+

--- a/test/spec/state-service-tests.js
+++ b/test/spec/state-service-tests.js
@@ -23,12 +23,12 @@ describe('Testing State service', function () {
     expect(State.geometries).toBeDefined();
   });
 
-  it('should set temporal.end to the max when set with a futuristic timestamp',
+  it('should NOT set temporal.end to the max when set with a futuristic timestamp',
     function () {
       var theVeryFarFuture = new Date();
       theVeryFarFuture.setYear(3050);
       State.temporal.end = theVeryFarFuture.getTime();
-      expect(State.temporal.end).toEqual(UtilService.MAX_TIME);
+      expect(State.temporal.end).not.toEqual(UtilService.MAX_TIME);
     }
   );
 

--- a/test/spec/util-service.js
+++ b/test/spec/util-service.js
@@ -107,10 +107,10 @@ describe('Testing util-service functions', function () {
     expect(result).toEqual(expectedResult);
   });
 
-  it('should return MIN_TIME for times earlier than MIN_TIME', function () {
+  it('should not return MIN_TIME for times earlier than MIN_TIME', function () {
     var early = UtilService.MIN_TIME - 1;
     var min = UtilService.getMinTime(early);
-    expect(min).toBe(UtilService.MIN_TIME);
+    expect(min).not.toBe(UtilService.MIN_TIME);
   });
 
   it('should identify urls', function () {


### PR DESCRIPTION
- [ ] Gebruik iconen uit Aquo standaard
- [ ] Tooltips hidden features @GeOdin 
- [x] Timeline should no longer be limited to a certain point in the future
- [x] Timeline should display different cursor on places where it is zoomable pannable and also this timeline should have different color.
- [ ] Endopoint favourites seems slow. Why?
- [x] Export modal popup. Close this popup when clicking outside of it
- [x] When creating a favourites  typing fast and hitting enter you receive error message that should not be there. @Derryrover 
- [ ] When showing multiple charts in the ‘grafieken’ context but these charts show no data, then show the text “No Data” to indicate that there was no data. @Derryrover 
- [x] Start & End times indicated at beginning and end of temporal raster timeline => seperate PR: https://github.com/nens/lizard-client/pull/1043
- [x] Annotations, find out how often and by who it is still used and if possible remove this feature.