### PR TITLE
Cleanup after Jenkins tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,16 +19,13 @@ pipeline {
                 sh "npm test"
             }
         }
-        if (env.BRANCH_NAME == "master") {
-            stage("Install transifex tools") {
-                steps {
-                    sh "npm install --optional=true"
-                }
+        stage("Transifex") {
+            when {
+                expression {env.BRANCH_NAME == "master"}
             }
-            stage("Transifex") {
-                steps {
-                    sh "npm run transifex"
-                }
+            steps {
+                sh "npm install --optional=true"
+                sh "npm run transifex"
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,20 +1,41 @@
-node ('nxt'){
-    stage "Checkout"
-    checkout scm
-
-    stage "Install"
-    sh "rm -rf node_modules"
-    sh "rm -rf vendor"
-    sh "npm install --optional=false"
-    sh "bower install"
-
-    stage "Test"
-    sh "npm test"
-
-    if (env.BRANCH_NAME == "master") {
-      stage "Install transifex tools"
-      sh "npm install --optional=true"
-      stage "Transifex"  
-      sh "npm run transifex"
+pipeline {
+    agent { label 'nxt' }
+    stages {
+        stage("Checkout") {
+            steps {
+                checkout scm
+            }
+        }
+        stage("Install") {
+            steps {
+                sh "rm -rf node_modules"
+                sh "rm -rf vendor"
+                sh "npm install --optional=false"
+                sh "bower install"
+            }
+        }
+        stage("Test") {
+            steps {
+                sh "npm test"
+            }
+        }
+        if (env.BRANCH_NAME == "master") {
+            stage("Install transifex tools") {
+                steps {
+                    sh "npm install --optional=true"
+                }
+            }
+            stage("Transifex") {
+                steps {
+                    sh "npm run transifex"
+                }
+            }
+        }
+    }
+    post {
+        always {
+            sh "rm -rf node_modules"
+            sh "rm -rf vendor"
+        }
     }
 }


### PR DESCRIPTION
The node_modules folder takes up 300M on the Jenkins server, so I now configured it using a "pipeline", that allows a "post" that will always be run to cleanup this folder.