### PR TITLE
[DONE]Tom timeline height across browsers

### DIFF
--- a/app/components/dashboard/dashboard-directive.js
+++ b/app/components/dashboard/dashboard-directive.js
@@ -67,7 +67,8 @@ angular.module('dashboard')
       };
 
       var getGraphHeight = function (element, nGraphs) {
-        return (element.height() - ROW_BOTTOM_MARGIN * nGraphs) / nGraphs;
+        // substract 30 from the element.height to give space to the date-timepickers left and right of the timeline
+        return ((element.height()- 30 ) - ROW_BOTTOM_MARGIN * nGraphs) / nGraphs;
       };
 
       /**

--- a/app/components/graph/graph-service.js
+++ b/app/components/graph/graph-service.js
@@ -36,8 +36,6 @@ angular.module('lizard-nxt')
    * @param {object} xDomain - override the domain for the graphs.
    */
   function Graph(element, dimensions, xDomain) {
-    console.log('[F] Graph');
-    dimensions.height = dimensions.height - 30;
     NxtD3.call(this, element, dimensions, xDomain);
     this._svg = this._createDrawingArea();
     this._containers = [];
@@ -48,8 +46,6 @@ angular.module('lizard-nxt')
   });
 
   Graph.prototype.resize = function (newDim) {
-    console.log('[F] Graph.prototype.resize ');
-    newDim.height = newDim.height - 30;
     NxtD3.prototype.resize.call(this, newDim);
     this._svg = this._createDrawingArea();
     this._svg.selectAll('.axis').remove();

--- a/app/components/graph/graph-service.js
+++ b/app/components/graph/graph-service.js
@@ -36,6 +36,8 @@ angular.module('lizard-nxt')
    * @param {object} xDomain - override the domain for the graphs.
    */
   function Graph(element, dimensions, xDomain) {
+    console.log('[F] Graph');
+    dimensions.height = dimensions.height - 30;
     NxtD3.call(this, element, dimensions, xDomain);
     this._svg = this._createDrawingArea();
     this._containers = [];
@@ -46,6 +48,8 @@ angular.module('lizard-nxt')
   });
 
   Graph.prototype.resize = function (newDim) {
+    console.log('[F] Graph.prototype.resize ');
+    newDim.height = newDim.height - 30;
     NxtD3.prototype.resize.call(this, newDim);
     this._svg = this._createDrawingArea();
     this._svg.selectAll('.axis').remove();

--- a/app/components/timeline/timeline-directives.js
+++ b/app/components/timeline/timeline-directives.js
@@ -446,11 +446,11 @@ angular.module('lizard-nxt')
         var defaultLanguageCode = "en_GB";
         var languageCode = LanguageLookup[urlLanguage] || defaultLanguageCode;
   
-        $('#timeline-header-datetimepicker-start').datetimepicker({
+        $('#timeline-header-datetimepicker-start', element).datetimepicker({
           date: moment(State.temporal.start),
           locale: languageCode,
         });
-        $('#timeline-header-datetimepicker-end').datetimepicker({
+        $('#timeline-header-datetimepicker-end', element).datetimepicker({
           date: moment(State.temporal.end),
           locale: languageCode,
         });
@@ -459,12 +459,12 @@ angular.module('lizard-nxt')
      
       // when language changes the date-time-picker should be removed and added again
       scope.$watch(State.toString('language'), function (n, o) {
-        $('#timeline-header-datetimepicker-start').data('DateTimePicker').destroy();
-        $('#timeline-header-datetimepicker-end').data('DateTimePicker').destroy();
+        $('#timeline-header-datetimepicker-start', element).data('DateTimePicker').destroy();
+        $('#timeline-header-datetimepicker-end', element).data('DateTimePicker').destroy();
         attachDateTimePickers();
       });
 
-      $("#timeline-header-datetimepicker-start").on("dp.change", function(e) {
+      $("#timeline-header-datetimepicker-start", element).on("dp.change", function(e) {
         var newStartTime = (new Date(e.date)).getTime();
 
         // if the new startTime is after the end time then also change the endtime:
@@ -491,7 +491,7 @@ angular.module('lizard-nxt')
         }
         timelineSetsTime = false;
       });
-      $("#timeline-header-datetimepicker-end").on("dp.change", function(e) {
+      $("#timeline-header-datetimepicker-end", element).on("dp.change", function(e) {
         var newEndTime = (new Date(e.date)).getTime();
         
         // if the new endTime is before the start time then also change the starttime:
@@ -520,11 +520,11 @@ angular.module('lizard-nxt')
       });
 
       scope.$watch(State.toString('temporal.start'), function (n, o) {
-        $('#timeline-header-datetimepicker-start').data("DateTimePicker").date(moment(parseInt(n)));
+        $('#timeline-header-datetimepicker-start', element).data("DateTimePicker").date(moment(parseInt(n)));
       });
 
       scope.$watch(State.toString('temporal.end'), function (n, o) {
-        $('#timeline-header-datetimepicker-end').data("DateTimePicker").date(moment(parseInt(n)));
+        $('#timeline-header-datetimepicker-end', element).data("DateTimePicker").date(moment(parseInt(n)));
       });
       
     }());
@@ -689,7 +689,6 @@ angular.module('lizard-nxt')
     window.addEventListener('load', getTimeLineData);
 
     var resize = function () {
-      console.log("[F] resize");
       var newWidth = getRequiredTimelineWidth(element);
       timeline.dimensions.width = newWidth;
 

--- a/app/components/timeline/timeline-service.js
+++ b/app/components/timeline/timeline-service.js
@@ -229,8 +229,11 @@ angular.module('lizard-nxt')
     resize: {
       value: function (newDimensions, timestamp, interval, nEvents) {
         var oldDimensions = angular.copy(this.dimensions);
+        // resize is also specified upon the ancestor #inheritage hell
+        // inside NxtD3.prototype.resize this.dimensions will be set from newDimensions
+        NxtD3.prototype.resize.call(this, newDimensions);
         this.updateElements(oldDimensions, timestamp, interval);
-        this._svg = resizeTimelineCanvas(this._svg, oldDimensions, this.dimensions);
+        this._svg = resizeTimelineCanvas(this, this._svg, oldDimensions, this.dimensions);        
         ordinalYScale = makeEventsYscale(initialHeight, this.dimensions);
         xScale.range([0, newDimensions.width - newDimensions.padding.right]);
         drawTimelineAxes(this._svg, xScale, newDimensions);
@@ -574,9 +577,9 @@ angular.module('lizard-nxt')
    *  bottom, left and right padding. All values in px.
    *  @param {object} newDims - new dimensions, same structure as oldDims.
    */
-  var resizeTimelineCanvas = function (svg, oldDims, newDims) {
+  var resizeTimelineCanvas = function (thisCurrentObj, svg, oldDims, newDims) {
     var width = Timeline.prototype._getWidth(newDims),
-    height = Timeline.prototype._getHeight(newDims);
+    height = thisCurrentObj._getHeight(newDims);
     if (newDims.height < oldDims.height) {
       svg.transition()
         .delay(Timeline.prototype.transTime)

--- a/app/lib/nxt-d3-service.js
+++ b/app/lib/nxt-d3-service.js
@@ -36,7 +36,7 @@ angular.module('lizard-nxt')
   function NxtD3(element, dimensions, xDomain) {
     this.dimensions = angular.copy(dimensions);
     this._xDomain = xDomain;
-    this._svg = createCanvas(element, this.dimensions);
+    this._svg = createCanvas(this, element, this.dimensions);
   }
 
   NxtD3.prototype = {
@@ -255,7 +255,7 @@ angular.module('lizard-nxt')
      */
     resize: function (dimensions) {
       this.dimensions = angular.extend(this.dimensions, dimensions);
-      this._svg = resizeCanvas(this._svg, this.dimensions);
+      this._svg = resizeCanvas(this, this._svg, this.dimensions);
       this._svg = this._createDrawingArea(this._svg, this.dimensions);
     },
 
@@ -550,10 +550,9 @@ angular.module('lizard-nxt')
    *                              values in px.
    * @return {object} svg         svg.
    */
-  createCanvas = function (element, dimensions) {
-
+  createCanvas = function (thisCurrentObj, element, dimensions) {
     var width = NxtD3.prototype._getWidth(dimensions),
-        height = NxtD3.prototype._getHeight(dimensions),
+        height = thisCurrentObj._getHeight(dimensions),
         svg = d3.select(element);
 
     // Create the svg as big as the dimensions
@@ -570,9 +569,9 @@ angular.module('lizard-nxt')
     return svg;
   };
 
-  resizeCanvas = function (svg, dimensions) {
+  resizeCanvas = function (thisCurrentObj, svg, dimensions) {
     var width = NxtD3.prototype._getWidth(dimensions),
-    height = NxtD3.prototype._getHeight(dimensions);
+      height = thisCurrentObj._getHeight(dimensions);
     // Create the svg as big as the dimensions
     svg.attr('width', dimensions.width)
       .attr('height', dimensions.height)
@@ -587,7 +586,7 @@ angular.module('lizard-nxt')
 
   createElementForAxis = function (svg, id, dimensions, y) {
     var className = y ? 'y axis': 'x axis',
-    transform = y ? 0: NxtD3.prototype._getHeight(dimensions);
+    transform = y ? 0: NxtD3.prototype._getHeight(dimensions);// + 20;
     return svg.select('g').append('g')
       .attr('class', className)
       .attr('id', id)

--- a/app/lib/nxt-d3-service.js
+++ b/app/lib/nxt-d3-service.js
@@ -586,7 +586,7 @@ angular.module('lizard-nxt')
 
   createElementForAxis = function (svg, id, dimensions, y) {
     var className = y ? 'y axis': 'x axis',
-    transform = y ? 0: NxtD3.prototype._getHeight(dimensions);// + 20;
+    transform = y ? 0: NxtD3.prototype._getHeight(dimensions);
     return svg.select('g').append('g')
       .attr('class', className)
       .attr('id', id)

--- a/app/styles/_timeline.scss
+++ b/app/styles/_timeline.scss
@@ -310,7 +310,6 @@
   fill: #ecf0f1;
   opacity: 0.4;
   cursor: col-resize;
-  height: 25px;
 }
 
 #timeline-header {


### PR DESCRIPTION
Note: 
May be possible to find better way to resize svg for not overlapping date-time picker.
Now the svg is resized with attribute d3.

The problem is partly because the date-time pickers are positioned outside their parent element.
The element that they overlap should thus be corrected for the size of the date-time picker, but only when drawing charts in the chart context. When the element containing the svg charts would have itself the right size then element.height would geve the right height dimensions. Now we need to hardcode element.height - 30. 
We might also pass the 30 around as a parameter, but I think this will even create more dependencies
