### PR TITLE
Fix wrong attribute names for groundwater filters

### DIFF
--- a/app/components/omnibox/wanted-attrs-constant.js
+++ b/app/components/omnibox/wanted-attrs-constant.js
@@ -227,15 +227,15 @@ angular.module('omnibox')
       },
       {
         keyName: gettext("Aquifer confinement"),
-        attrName: "aquifer_confiment",
-        ngBindValue: "waterchain.aquifer_confiment",
+        attrName: "aquifer_confinement",
+        ngBindValue: "waterchain.aquifer_confinement",
         valueSuffix: ""
       },
       {
         /// bodemsoort
         keyName: gettext("Lithology"),
-        attrName: "litology",
-        ngBindValue: "waterchain.litology",
+        attrName: "lithology",
+        ngBindValue: "waterchain.lithology",
         valueSuffix: ""
       },
       {


### PR DESCRIPTION
Misspelled attributes lithology and aquifer_confinement are fixed in the API some time ago, but client wasn't adapted.