### PR TITLE
Adding slash breaks GetFeatureInfo

### DIFF
--- a/app/lib/wms-get-feature-info-service.js
+++ b/app/lib/wms-get-feature-info-service.js
@@ -67,7 +67,7 @@ angular.module('lizard-nxt')
         + "layer looks like:", layer);
     }
 
-    var url = layer.getFeatureInfoUrl + '/?';
+    var url = layer.getFeatureInfoUrl + '?';
     for (var key in params) {
       if (url !== "") {
           url += "&";


### PR DESCRIPTION
This breaks the request for a particular service. Geoserver works both with and without the slash. We can always include it in the configuration if it is required for another WMS service.